### PR TITLE
Fix oversized company email index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 ## Unreleased
 ### Changed
 - Updated OpenAI model defaults for HN job extraction to `gpt-5.4-nano`, salary parsing to `gpt-5-nano`, and made chat/embedding model names configurable via Django settings.
+- Removed the unsafe btree index on `Company.emails` and bounded the denormalized company email summary to prevent oversized index-row errors during HN job analysis.
 
 ## [0.0.3] - 2024-06-25
 ### Added

--- a/jobs/migrations/0032_remove_company_emails_index.py
+++ b/jobs/migrations/0032_remove_company_emails_index.py
@@ -1,0 +1,17 @@
+# Generated manually to remove an unsafe btree index on a large text field.
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("jobs", "0031_technology_index_t_technology_slug"),
+    ]
+
+    operations = [
+        migrations.RemoveIndex(
+            model_name="company",
+            name="index_company_emails",
+        ),
+    ]

--- a/jobs/models.py
+++ b/jobs/models.py
@@ -133,7 +133,6 @@ class Company(TimeStampedModel):
     class Meta:
         indexes = [
             models.Index(fields=["name"], name="index_company_name"),
-            models.Index(fields=["emails"], name="index_company_emails"),
             models.Index(fields=["company_homepage_link"], name="index_company_homepage_link"),
         ]
 

--- a/jobs/tasks.py
+++ b/jobs/tasks.py
@@ -29,6 +29,29 @@ logger = get_tjalerts_logger(__name__)
 
 client = OpenAI()
 
+MAX_COMPANY_EMAILS_LENGTH = 2000
+
+
+def merge_company_emails(existing_emails, new_emails):
+    """Keep Company.emails as a bounded, comma-separated summary.
+
+    Post.emails and the Email model are the source of truth for extracted
+    contact info. Company.emails is only a denormalized convenience field, so
+    it should never grow without bound or break unrelated company saves.
+    """
+
+    emails = []
+    seen = set()
+
+    for email_blob in (existing_emails, new_emails):
+        for email in email_blob.split(","):
+            email = email.strip()
+            if email and email not in seen:
+                emails.append(email)
+                seen.add(email)
+
+    return ", ".join(emails)[:MAX_COMPANY_EMAILS_LENGTH]
+
 
 def get_hn_pages_to_analyze(who_is_hiring_post_id):
     data = httpx.get(f"https://hacker-news.firebaseio.com/v0/item/{who_is_hiring_post_id}.json").json()
@@ -149,7 +172,7 @@ def analyze_hn_page(who_is_hiring_id, who_is_hiring_title, comment_id):
 
     company_obj, _ = Company.objects.get_or_create(name=cleaned_data["company_name"])
     company_obj.company_homepage_link = cleaned_data["company_homepage_link"]
-    company_obj.emails += cleaned_data["emails"]
+    company_obj.emails = merge_company_emails(company_obj.emails, cleaned_data["emails"])
     company_obj.save()
 
     post = Post(

--- a/jobs/tests.py
+++ b/jobs/tests.py
@@ -1,3 +1,15 @@
-from django.test import TestCase
+from django.test import SimpleTestCase
 
-# Create your tests here.
+from jobs.tasks import MAX_COMPANY_EMAILS_LENGTH, merge_company_emails
+
+
+class CompanyEmailMergeTests(SimpleTestCase):
+    def test_merge_company_emails_deduplicates_and_adds_separator(self):
+        assert merge_company_emails("a@example.com", "b@example.com, a@example.com") == (
+            "a@example.com, b@example.com"
+        )
+
+    def test_merge_company_emails_is_bounded(self):
+        long_email_blob = "a" * (MAX_COMPANY_EMAILS_LENGTH + 100)
+
+        assert len(merge_company_emails("", long_email_blob)) == MAX_COMPANY_EMAILS_LENGTH


### PR DESCRIPTION
## Summary
- remove the unsafe btree index on `Company.emails`, which Sentry shows is failing once the denormalized text field grows past Postgres index row limits
- bound and dedupe `Company.emails` updates in `analyze_hn_page` so future company saves don't keep growing an unbounded concatenated email blob
- add coverage for the company email merge helper
- update `CHANGELOG.md`

## Sentry findings
- Issue `HNJOBS-DGY` / `6944924456`: `OperationalError: index row size ... exceeds btree ... for index "index_company_emails"`
- Last seen on release `89c63d3b9bfb484630caf970b95d3a1275735e2f`, in `jobs.tasks.analyze_hn_page` at `company_obj.save()`
- The project currently has no Sentry transaction events over 24h/7d/30d/90d (`firstTransactionEvent=false`, `hasInsightsDb=false`), so there wasn't usable Sentry DB span data to justify additional performance indexes in this PR.

## Checks
- `python3 -m compileall -q hn_jobs jobs`
- `git diff --check`
- `uv run python manage.py makemigrations --check --dry-run`
- `uv run python manage.py migrate --plan jobs`
- `uv run python manage.py test jobs --noinput`