### PR TITLE
[SEO] Repair Metadata and Sitemap Coverage

### DIFF
--- a/hn_jobs/settings/base.py
+++ b/hn_jobs/settings/base.py
@@ -34,6 +34,7 @@ env = environ.Env(
 )
 
 ENVIRONMENT = env("ENVIRONMENT")
+SITE_URL = env("SITE_URL", default="https://gettjalerts.com").rstrip("/")
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.0/howto/deployment/checklist/
 
@@ -118,6 +119,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "hn_jobs.utils.site_metadata",
             ],
         },
     },

--- a/hn_jobs/settings/production.py
+++ b/hn_jobs/settings/production.py
@@ -7,6 +7,13 @@ LOGGING["loggers"]["django_structlog"]["handlers"].append("json_console")
 LOGGING["loggers"]["tjalerts"]["level"] = env("DJANGO_LOG_LEVEL", default="INFO")
 LOGGING["loggers"]["tjalerts"]["handlers"].append("json_console")
 
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+SECURE_HSTS_SECONDS = env.int("SECURE_HSTS_SECONDS", default=31536000)
+SECURE_HSTS_INCLUDE_SUBDOMAINS = env.bool("SECURE_HSTS_INCLUDE_SUBDOMAINS", default=False)
+SECURE_HSTS_PRELOAD = env.bool("SECURE_HSTS_PRELOAD", default=False)
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
+
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.redis.RedisCache",

--- a/hn_jobs/sitemaps.py
+++ b/hn_jobs/sitemaps.py
@@ -48,7 +48,7 @@ class HighestPaidJobsListicleSitemap(sitemaps.Sitemap):
         )
 
     def lastmod(self, obj):
-        return obj.post.order_by("-submitted_datetime").first().submitted_datetime
+        return Post.objects.filter(technologies=obj).aggregate(latest_date=Max("submitted_datetime"))["latest_date"]
 
     def location(self, obj):
         return reverse("highest-paid-job-blog-post", kwargs={"slug": obj.slug})

--- a/hn_jobs/sitemaps.py
+++ b/hn_jobs/sitemaps.py
@@ -18,6 +18,10 @@ class StaticViewSitemap(sitemaps.Sitemap):
     def items(self):
         return [
             "home",
+            "support",
+            "privacy",
+            "tos",
+            "uses",
             "companies",
             "technologies",
             "titles",
@@ -42,7 +46,6 @@ class HighestPaidJobsListicleSitemap(sitemaps.Sitemap):
         )
 
     def lastmod(self, obj):
-        print(obj)
         return obj.post.order_by("-submitted_datetime").first().submitted_datetime
 
     def location(self, obj):
@@ -141,21 +144,30 @@ class BlogPostSitemap(sitemaps.Sitemap):
         return reverse("blog-post", kwargs={"slug": obj.slug})
 
 
+class RecentPostSitemap(sitemaps.Sitemap):
+    changefreq = "daily"
+    priority = 0.7
+    protocol = "https"
+
+    def items(self):
+        two_months_ago = timezone.now() - timezone.timedelta(days=60)
+        return Post.objects.filter(created__gte=two_months_ago).exclude(description="")
+
+    def lastmod(self, obj):
+        return obj.modified
+
+    def location(self, obj):
+        return obj.get_absolute_url()
+
+
 sitemaps = {
     "sitemaps": {
         "static": StaticViewSitemap,
         "blog-posts": BlogPostSitemap,
-        # "highest_paid_jobs_listicle": HighestPaidJobsListicleSitemap,
-        # "company_jobs": CompaniesJobsListicleSitemap,
-        # "technology_jobs": TechnologiesJobsListicleSitemap,
-        # "title_jobs": TitlesJobsListicleSitemap,
-        # "posts": GenericSitemap(
-        #     {
-        #         "queryset": Post.objects.filter(created__gte=timezone.now() - timezone.timedelta(days=60)),
-        #         "date_field": "modified",
-        #     },
-        #     priority=0.7,
-        #     protocol="https",
-        # ),
+        "highest_paid_jobs_listicle": HighestPaidJobsListicleSitemap,
+        "company_jobs": CompaniesJobsListicleSitemap,
+        "technology_jobs": TechnologiesJobsListicleSitemap,
+        "title_jobs": TitlesJobsListicleSitemap,
+        "posts": RecentPostSitemap,
     }
 }

--- a/hn_jobs/sitemaps.py
+++ b/hn_jobs/sitemaps.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django.contrib import sitemaps
 
 # from django.contrib.sitemaps import GenericSitemap
@@ -58,7 +60,7 @@ class CompaniesJobsListicleSitemap(sitemaps.Sitemap):
     protocol = "https"
 
     def items(self):
-        two_months_ago = timezone.now() - timezone.timedelta(days=60)
+        two_months_ago = timezone.now() - timedelta(days=60)
         recent_posts = Post.objects.filter(submitted_datetime__gte=two_months_ago).values("company")
 
         companies_with_recent_posts = (
@@ -82,7 +84,7 @@ class TechnologiesJobsListicleSitemap(sitemaps.Sitemap):
     protocol = "https"
 
     def items(self):
-        two_months_ago = timezone.now() - timezone.timedelta(days=60)
+        two_months_ago = timezone.now() - timedelta(days=60)
         recent_posts = Post.objects.filter(submitted_datetime__gte=two_months_ago).values("technologies")
 
         technologies_with_recent_posts = (
@@ -109,7 +111,7 @@ class TitlesJobsListicleSitemap(sitemaps.Sitemap):
     protocol = "https"
 
     def items(self):
-        two_months_ago = timezone.now() - timezone.timedelta(days=60)
+        two_months_ago = timezone.now() - timedelta(days=60)
         recent_posts = Post.objects.filter(submitted_datetime__gte=two_months_ago).values("titles")
 
         titles_with_recent_posts = (
@@ -150,7 +152,7 @@ class RecentPostSitemap(sitemaps.Sitemap):
     protocol = "https"
 
     def items(self):
-        two_months_ago = timezone.now() - timezone.timedelta(days=60)
+        two_months_ago = timezone.now() - timedelta(days=60)
         return Post.objects.filter(created__gte=two_months_ago).exclude(description="")
 
     def lastmod(self, obj):

--- a/hn_jobs/tests.py
+++ b/hn_jobs/tests.py
@@ -1,0 +1,17 @@
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from hn_jobs.sitemaps import HighestPaidJobsListicleSitemap
+
+
+class SitemapTests(SimpleTestCase):
+    def test_highest_paid_jobs_lastmod_returns_none_without_posts(self):
+        technology = object()
+
+        with patch("hn_jobs.sitemaps.Post.objects.filter") as filter_mock:
+            filter_mock.return_value.aggregate.return_value = {"latest_date": None}
+
+            assert HighestPaidJobsListicleSitemap().lastmod(technology) is None
+
+        filter_mock.assert_called_once_with(technologies=technology)

--- a/hn_jobs/utils.py
+++ b/hn_jobs/utils.py
@@ -5,6 +5,7 @@ from urllib.parse import unquote
 import posthog
 import structlog
 from allauth.account.models import EmailAddress
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.forms.utils import ErrorList
 
@@ -18,6 +19,20 @@ def get_tjalerts_logger(name):
 
 
 logger = get_tjalerts_logger(__name__)
+
+
+def build_absolute_site_url(path="/"):
+    if not path.startswith("/"):
+        path = f"/{path}"
+
+    return f"{settings.SITE_URL}{path}"
+
+
+def site_metadata(request):
+    return {
+        "SITE_URL": settings.SITE_URL,
+        "SITE_NAME": "Tech Job Alerts",
+    }
 
 
 def add_users_context(context, user, self=None):

--- a/hn_jobs/utils.py
+++ b/hn_jobs/utils.py
@@ -31,7 +31,6 @@ def build_absolute_site_url(path="/"):
 def site_metadata(request):
     return {
         "SITE_URL": settings.SITE_URL,
-        "SITE_NAME": "Tech Job Alerts",
     }
 
 

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -16,7 +16,7 @@ from django.views.generic import CreateView, DetailView, ListView, TemplateView,
 from django_filters.views import FilterView
 from django_q.tasks import async_task
 
-from hn_jobs.utils import add_users_context, get_tjalerts_logger, validate_technology_selected
+from hn_jobs.utils import add_users_context, build_absolute_site_url, get_tjalerts_logger, validate_technology_selected
 from jobs.constants import EXCLUDED_TECHNOLOGIES, EXCLUDED_TITLES
 from jobs.filters import PostFilter
 from jobs.forms import ConfirmAlertForm, CreateAlertForm, CreateCustomAlertForm
@@ -95,6 +95,7 @@ class PostListView(FilterView):
         context["title"] = title
         context["date"] = date
         context["keywords"] = ", ".join(map(str, keywords))
+        context["canonical_url"] = build_absolute_site_url(self.request.path)
 
         return context
 
@@ -147,7 +148,7 @@ class HighestPaidJobsView(ListView):
 
         context["tech_name"] = tech.name
         context["tech_id"] = tech.id
-        context["canonical_url"] = self.request.build_absolute_uri(self.request.path).replace("http://", "https://")
+        context["canonical_url"] = build_absolute_site_url(self.request.path)
         context["latest_date"] = latest_date
         context["create_alert_form"] = CreateAlertForm
 
@@ -421,6 +422,7 @@ class CompanyJobsView(ListView):
         else:
             # Handle the case where no company is found
             context["company"] = None
+        context["canonical_url"] = build_absolute_site_url(self.request.path)
         return context
 
 
@@ -452,7 +454,7 @@ class TechnologyJobsView(ListView):
         context["tech_name"] = tech.name if tech else ""
         context["tech_id"] = tech.id if tech else None
         context["tech_slug"] = tech.slug if tech else ""
-        context["canonical_url"] = self.request.build_absolute_uri(self.request.path).replace("http://", "https://")
+        context["canonical_url"] = build_absolute_site_url(self.request.path)
         context["latest_date"] = latest_date
         context["create_alert_form"] = CreateAlertForm
 
@@ -565,7 +567,7 @@ class TitleJobsView(ListView):
         context["title_name"] = title.name
         context["title_id"] = title.id
         context["title_slug"] = title.slug
-        context["canonical_url"] = self.request.build_absolute_uri(self.request.path).replace("http://", "https://")
+        context["canonical_url"] = build_absolute_site_url(self.request.path)
         context["latest_date"] = latest_date
         context["create_alert_form"] = CreateAlertForm
 

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -422,7 +422,6 @@ class CompanyJobsView(ListView):
         else:
             # Handle the case where no company is found
             context["company"] = None
-        context["canonical_url"] = build_absolute_site_url(self.request.path)
         return context
 
 

--- a/templates/account/email_confirm.html
+++ b/templates/account/email_confirm.html
@@ -2,7 +2,8 @@
 {% load widget_tweaks %}
 
 {% block meta %}
-  <title>TJ Alerts - Confirm Email</title>
+<title>Confirm Email | Tech Job Alerts</title>
+<meta name="robots" content="noindex, follow" />
 {% endblock meta %}
 
 {% block content %}

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -2,6 +2,11 @@
 {% load widget_tweaks %}
 {% load socialaccount %}
 
+{% block meta %}
+<title>Log In | Tech Job Alerts</title>
+<meta name="robots" content="noindex, follow" />
+{% endblock meta %}
+
 {% block content %}
     <div class="flex justify-center items-center px-4 py-12 my-4 sm:px-6 lg:px-8">
         <div class="space-y-8 w-full max-w-md">

--- a/templates/account/logout.html
+++ b/templates/account/logout.html
@@ -1,6 +1,10 @@
-
-{% extends 'base.html' %}
+{% extends "base.html" %}
 {% load widget_tweaks %}
+
+{% block meta %}
+<title>Sign Out | Tech Job Alerts</title>
+<meta name="robots" content="noindex, follow" />
+{% endblock meta %}
 
 {% block content %}
     <div class="mx-auto my-4 prose md:my-10 lg:prose-lg">

--- a/templates/account/settings.html
+++ b/templates/account/settings.html
@@ -2,6 +2,11 @@
 {% load widget_tweaks %}
 {% load alert_extras %}
 
+{% block meta %}
+<title>Settings | Tech Job Alerts</title>
+<meta name="robots" content="noindex, follow" />
+{% endblock meta %}
+
 {% block content %}
 
 <main class="bg-white lg:min-w-0 md:pt-10 lg:flex-1">

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -2,6 +2,11 @@
 {% load widget_tweaks %}
 {% load socialaccount %}
 
+{% block meta %}
+<title>Sign Up | Tech Job Alerts</title>
+<meta name="robots" content="noindex, follow" />
+{% endblock meta %}
+
 {% block content %}
 <div class="flex justify-center items-center px-4 py-12 my-4 sm:px-6 lg:px-8">
   <div class="space-y-8 w-full max-w-md">

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,13 +18,13 @@
   <meta name="description" content="Get notified when the new Tech Jobs are published." />
   <meta name="keywords" content="jobs, tech jobs, tech jobs alerts" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://{{ request.get_host }}/" />
+  <link rel="canonical" href="{{ SITE_URL }}/" />
 
   <meta property="og:type" content="website" />
   <meta property="og:title" content="Tech Job Alerts" />
-  <meta property="og:url" content="https://{{ request.get_host }}/" />
+  <meta property="og:url" content="{{ SITE_URL }}/" />
   <meta property="og:description" content="Get notified when the new Tech Jobs are published." />
-  <meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+  <meta property="og:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
   <meta property="og:locale" content="en_US" />
 
   <meta name="twitter:card" content="summary" />
@@ -32,7 +32,7 @@
   <meta name="twitter:site" content="@rasulkireev" />
   <meta name="twitter:title" content="Tech Job Alerts" />
   <meta name="twitter:description" content="Get notified when the new Tech Jobs are published." />
-  <meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+  <meta name="twitter:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
   {% endblock meta %}
 
   {% stylesheet_pack 'index' %}
@@ -239,8 +239,8 @@
       "@type": "WebSite",
       "name": "Tech Job Alerts",
       "description": "Get notified when the new Tech Jobs are published.",
-      "thumbnailUrl": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}",
-      "url": "https://{{ request.get_host }}/",
+      "thumbnailUrl": "{{ SITE_URL }}{% static 'vendors/images/logo.png' %}",
+      "url": "{{ SITE_URL }}/",
       "author": {
         "@type": "Person",
         "givenName": "Rasul",

--- a/templates/blog/blog-post-detail.html
+++ b/templates/blog/blog-post-detail.html
@@ -8,20 +8,20 @@
 {% block meta %}
 <title>{{ object.title }} - TJ Alerts Blog</title>
 <meta name="description" content="{{ object.description }}" />
-<link rel="canonical" href="https://{{ request.get_host }}{{ object.get_absolute_url }}" />
+<link rel="canonical" href="{{ SITE_URL }}{{ object.get_absolute_url }}" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:creator" content="@rasulkireev" />
 <meta name="twitter:title" content="{{ object.title }}" />
 <meta name="twitter:description" content="{{ object.description }}" />
-<meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+<meta name="twitter:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
 <meta property="og:title" content="{{ object.title }}" />
-<meta property="og:url" content="https://{{ request.get_host }}{{ object.get_absolute_url }}" />
+<meta property="og:url" content="{{ SITE_URL }}{{ object.get_absolute_url }}" />
 <meta property="og:description" content="{{ object.description }}" />
-<meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+<meta property="og:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
 {% endblock meta %}
 
 {% block content %}
-<article itemscope itemtype="https://schema.org/BlogPosting" itemid="{{ request.build_absolute_uri }}">
+<article itemscope itemtype="https://schema.org/BlogPosting" itemid="{{ SITE_URL }}{{ object.get_absolute_url }}">
   <div class="px-6 py-20 bg-white lg:px-8">
     <div class="mx-auto max-w-4xl text-base leading-7 text-gray-700">
       <header>
@@ -81,7 +81,7 @@
   "@type": "BlogPosting",
   "headline": "{{ object.title }}",
   "description": "{{ object.description }}",
-  "image": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}",
+  "image": "{{ SITE_URL }}{% static 'vendors/images/logo.png' %}",
   "author": {
     "@type": "Person",
     "name": "Rasul Kireev",
@@ -92,7 +92,7 @@
     "name": "TJ Alerts",
     "logo": {
       "@type": "ImageObject",
-      "url": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}"
+      "url": "{{ SITE_URL }}{% static 'vendors/images/logo.png' %}"
     }
   },
   "datePublished": "{{ object.created|date:'c' }}",
@@ -100,7 +100,7 @@
   "articleBody": "{{ object.content|safe|replace_quotes }}",
   "mainEntityOfPage": {
     "@type": "WebPage",
-    "@id": "{{ request.build_absolute_uri }}"
+    "@id": "{{ SITE_URL }}{{ object.get_absolute_url }}"
   }
 }
 </script>

--- a/templates/blog/blog-post-list.html
+++ b/templates/blog/blog-post-list.html
@@ -5,6 +5,27 @@
 {% load url_utils %}
 {% load blog_post_extras %}
 
+{% block meta %}
+<title>Tech Job Alerts Blog</title>
+<meta name="description" content="Tech job search advice, hiring trends, and monthly Who is Hiring summaries from Tech Job Alerts." />
+<meta name="robots" content="index, follow" />
+<link rel="canonical" href="{{ SITE_URL }}{% url 'blog-posts' %}" />
+
+<meta property="og:type" content="website" />
+<meta property="og:title" content="Tech Job Alerts Blog" />
+<meta property="og:url" content="{{ SITE_URL }}{% url 'blog-posts' %}" />
+<meta property="og:description" content="Tech job search advice, hiring trends, and monthly Who is Hiring summaries from Tech Job Alerts." />
+<meta property="og:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
+<meta property="og:locale" content="en_US" />
+
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:creator" content="@rasulkireev" />
+<meta name="twitter:site" content="@rasulkireev" />
+<meta name="twitter:title" content="Tech Job Alerts Blog" />
+<meta name="twitter:description" content="Tech job search advice, hiring trends, and monthly Who is Hiring summaries from Tech Job Alerts." />
+<meta name="twitter:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
+{% endblock meta %}
+
 {% block content %}
 
 <div class="overflow-hidden mx-auto mb-16 max-w-7xl bg-white sm:mb-24">

--- a/templates/components/technology-link.html
+++ b/templates/components/technology-link.html
@@ -1,7 +1,7 @@
 {% load post_extras %}
 
 {% with technology|replace_child_with_parent_technology as technology %}
-<a href="{% url 'posts' %}?technologies={{ technology.id }}" class="inline-flex items-center px-2 py-1 my-1 text-sm font-medium text-green-700 rounded-md bg-green-50 ring-1 ring-inset ring-green-600/20 hover:ring-2 hover:ring-green-800">
+<a href="{% url 'technology-jobs' technology.slug %}" class="inline-flex items-center px-2 py-1 my-1 text-sm font-medium text-green-700 rounded-md bg-green-50 ring-1 ring-inset ring-green-600/20 hover:ring-2 hover:ring-green-800">
   {{ technology.name }}
 </a>
 {% endwith %}

--- a/templates/components/title-link.html
+++ b/templates/components/title-link.html
@@ -1,5 +1,5 @@
 {% load post_extras %}
 
-<a href="{% url 'posts' %}?titles={{ title.id }}" class="inline-flex items-center px-2 py-1 my-1 text-sm font-medium text-green-700 bg-green-50 rounded-md ring-1 ring-inset ring-green-600/20 hover:ring-2 hover:ring-green-800">
+<a href="{% url 'title-jobs' title.slug %}" class="inline-flex items-center px-2 py-1 my-1 text-sm font-medium text-green-700 bg-green-50 rounded-md ring-1 ring-inset ring-green-600/20 hover:ring-2 hover:ring-green-800">
   {{ title.name }}
 </a>

--- a/templates/jobs/all_jobs.html
+++ b/templates/jobs/all_jobs.html
@@ -16,7 +16,7 @@
 <meta property="og:title" content="{{ title }}" />
 <meta property="og:url" content="{{ canonical_url }}" />
 <meta property="og:description" content="Jobs that match these keywords: {{ keywords }}. From {{ date }}." />
-<meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+<meta property="og:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
 <meta property="og:locale" content="en_US" />
 
 <meta name="twitter:card" content="summary" />
@@ -24,7 +24,7 @@
 <meta name="twitter:site" content="@rasulkireev" />
 <meta name="twitter:title" content="{{ title }}" />
 <meta name="twitter:description" content="Jobs that match these keywords: {{ keywords }}. From {{ date }}." />
-<meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+<meta name="twitter:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
 {% endblock meta %}
 
 {% block content %}
@@ -248,11 +248,11 @@
     {
       "@type": "ListItem",
       "position": {{ forloop.counter }},
-      "url": "https://{{ request.get_host }}{% url 'post' job.id %}",
+      "url": "{{ SITE_URL }}{% url 'post' job.id %}",
       "item": {
         "@type": "JobPosting",
-        "name":"{% if job.jobs %}{{ job.titles.all.0.name }}{% else %}Developer{% endif %}",
-        "{{ title }}":"{% if job.jobs %}{{ job.titles.all.0.name }}{% else %}Developer{% endif %}",
+        "name": "{{ job.titles.all.0.name|default:'Developer'|replace_quotes }}",
+        "title": "{{ job.titles.all.0.name|default:'Developer'|replace_quotes }}",
         "jobLocation": {
           "@type": "Place",
           "address": {% if job.locations %}"{{ job.locations }}"{% else %}"Remote"{% endif %}

--- a/templates/jobs/companies-with-jobs.html
+++ b/templates/jobs/companies-with-jobs.html
@@ -9,13 +9,13 @@
 <meta name="description" content="List of companies that are hiring right now." />
 <meta name="keywords" content="companies, hiring, jobs" />
 <meta name="robots" content="index, follow" />
-<link rel="canonical" href="https://{{ request.get_host }}{% url 'companies' %}" />
+<link rel="canonical" href="{{ SITE_URL }}{% url 'companies' %}" />
 
 <meta property="og:type" content="website" />
 <meta property="og:title" content="Companies that are hiring right now." />
-<meta property="og:url" content="https://{{ request.get_host }}{% url 'companies' %}" />
+<meta property="og:url" content="{{ SITE_URL }}{% url 'companies' %}" />
 <meta property="og:description" content="List of companies that are hiring right now." />
-<meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+<meta property="og:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
 <meta property="og:locale" content="en_US" />
 
 <meta name="twitter:card" content="summary" />
@@ -23,7 +23,7 @@
 <meta name="twitter:site" content="@rasulkireev" />
 <meta name="twitter:title" content="Companies that are hiring right now." />
 <meta name="twitter:description" content="List of companies that are hiring right now." />
-<meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+<meta name="twitter:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
 {% endblock meta %}
 
 {% block content %}
@@ -56,7 +56,7 @@
     {
       "@type": "ListItem",
       "position": {{ forloop.counter }},
-      "url": "https://{{ request.get_host }}{% url 'company-jobs' company.slug %}",
+      "url": "{{ SITE_URL }}{% url 'company-jobs' company.slug %}",
       "item": {
         "@type": "Organization",
         "name": "{{ company.name }}"{% if company.company_homepage_link %},

--- a/templates/jobs/company-jobs.html
+++ b/templates/jobs/company-jobs.html
@@ -10,13 +10,13 @@
 <meta name="description" content="List of jobs at {{ company.name }}" />
 <meta name="keywords" content="jobs, job postings, {{ company.name }}" />
 <meta name="robots" content="index, follow" />
-<link rel="canonical" href="https://{{ request.get_host }}{% url 'company-jobs' company.slug %}" />
+<link rel="canonical" href="{{ SITE_URL }}{% url 'company-jobs' company.slug %}" />
 
 <meta property="og:type" content="website" />
 <meta property="og:title" content="Jobs at {{ company.name }}" />
-<meta property="og:url" content="https://{{ request.get_host }}{% url 'company-jobs' company.slug %}" />
+<meta property="og:url" content="{{ SITE_URL }}{% url 'company-jobs' company.slug %}" />
 <meta property="og:description" content="List of jobs at {{ company.name }}" />
-<meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+<meta property="og:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
 <meta property="og:locale" content="en_US" />
 
 <meta name="twitter:card" content="summary" />
@@ -24,7 +24,7 @@
 <meta name="twitter:site" content="@rasulkireev" />
 <meta name="twitter:title" content="Jobs at {{ company.name }}" />
 <meta name="twitter:description" content="List of jobs at {{ company.name }}" />
-<meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+<meta name="twitter:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
 {% endblock meta %}
 
 {% block content %}
@@ -57,10 +57,10 @@
     {
       "@type": "ListItem",
       "position": {{ forloop.counter }},
-      "url": "https://{{ request.get_host }}{% url 'post' job.id %}",
+      "url": "{{ SITE_URL }}{% url 'post' job.id %}",
       "item": {
         "@type": "JobPosting",
-        "title": "{{ job.titles.all.0.name }}",
+        "title": "{{ job.titles.all.0.name|default:'Developer'|replace_quotes }}",
         "description": "{{ job.description|safe }}",
         "datePosted": "{{ job.submitted_datetime|date:'Y-m-d' }}",
         "validThrough": "{{ job.submitted_datetime|plus_days:30|date:'Y-m-d' }}",

--- a/templates/jobs/highest-paid-job.html
+++ b/templates/jobs/highest-paid-job.html
@@ -15,7 +15,7 @@
 <meta property="og:title" content="Top 10 Highest Paying Companies that use {{ tech_name }}" />
 <meta property="og:url" content="{{ canonical_url }}" />
 <meta property="og:description" content="List of the top 10 highest paying companies that use {{ tech_name }}." />
-<meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+<meta property="og:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
 <meta property="og:locale" content="en_US" />
 
 <meta name="twitter:card" content="summary" />
@@ -23,7 +23,7 @@
 <meta name="twitter:site" content="@rasulkireev" />
 <meta name="twitter:title" content="Top 10 Highest Paying Companies that use {{ tech_name }}" />
 <meta name="twitter:description" content="List of the top 10 highest paying companies that use {{ tech_name }}." />
-<meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+<meta name="twitter:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
 {% endblock meta %}
 
 {% block content %}

--- a/templates/jobs/post_detail.html
+++ b/templates/jobs/post_detail.html
@@ -11,16 +11,16 @@
 <meta name="robots" content="noindex" />
 {% endif %}
 <meta name="description" content="{{ object.description }}" />
-<link rel="canonical" href="https://{{ request.get_host }}/jobs/{{ object.id }}" />
+<link rel="canonical" href="{{ SITE_URL }}/jobs/{{ object.id }}" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:creator" content="@rasulkireev" />
 <meta name="twitter:title" content="{{ object.company.name }} is hiring - {{ object.created | date:"F Y" }}" />
 <meta name="twitter:description" content="{{ object.description }}" />
-<meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+<meta name="twitter:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
 <meta property="og:title" content="{{ object.company.name }} is hiring - {{ object.created | date:"F Y" }}" />
-<meta property="og:url" content="https://{{ request.get_host }}/jobs/{{ object.id }}" />
+<meta property="og:url" content="{{ SITE_URL }}/jobs/{{ object.id }}" />
 <meta property="og:description" content="{{ object.description }}" />
-<meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+<meta property="og:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
 {% endblock meta %}
 
 {% block content %}
@@ -156,8 +156,8 @@
     {
       "@context": "https://schema.org",
       "@type": "JobPosting",
-      "name":"{% if object.jobs %}{{ object.titles.all.0.name }}{% else %}Developer{% endif %}",
-      "title":"{% if object.jobs %}{{ object.titles.all.0.name }}{% else %}Developer{% endif %}",
+      "name": "{{ object.titles.all.0.name|default:'Developer'|replace_quotes }}",
+      "title": "{{ object.titles.all.0.name|default:'Developer'|replace_quotes }}",
       "jobLocation": {
         "@type": "Place",
         "address": {% if object.locations %}"{{ object.locations }}"{% else %}"Remote"{% endif %}

--- a/templates/jobs/technologies-with-jobs.html
+++ b/templates/jobs/technologies-with-jobs.html
@@ -9,13 +9,13 @@
 <meta name="description" content="List of technologies that are in demand right now." />
 <meta name="keywords" content="technologies, hiring, jobs" />
 <meta name="robots" content="index, follow" />
-<link rel="canonical" href="https://{{ request.get_host }}{% url 'technologies' %}" />
+<link rel="canonical" href="{{ SITE_URL }}{% url 'technologies' %}" />
 
 <meta property="og:type" content="website" />
 <meta property="og:title" content="Technologies that are in demand right now." />
-<meta property="og:url" content="https://{{ request.get_host }}{% url 'technologies' %}" />
+<meta property="og:url" content="{{ SITE_URL }}{% url 'technologies' %}" />
 <meta property="og:description" content="List of technologies that are in demand right now." />
-<meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+<meta property="og:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
 <meta property="og:locale" content="en_US" />
 
 <meta name="twitter:card" content="summary" />
@@ -23,7 +23,7 @@
 <meta name="twitter:site" content="@rasulkireev" />
 <meta name="twitter:title" content="Technologies that are in demand right now." />
 <meta name="twitter:description" content="List of technologies that are in demand right now." />
-<meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+<meta name="twitter:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
 {% endblock meta %}
 
 {% block content %}
@@ -57,7 +57,7 @@
     {
       "@type": "ListItem",
       "position": {{ forloop.counter }},
-      "url": "https://{{ request.get_host }}{% url 'technology-jobs' technology.slug %}",
+      "url": "{{ SITE_URL }}{% url 'technology-jobs' technology.slug %}",
       "item": {
         "@type": "Organization",
         "name": "{{ technology.name }}"

--- a/templates/jobs/technology-jobs.html
+++ b/templates/jobs/technology-jobs.html
@@ -10,13 +10,13 @@
 <meta name="description" content="List of jobs with {{ tech_name }}" />
 <meta name="keywords" content="jobs, job postings, {{ object_list.0.company.name }}" />
 <meta name="robots" content="index, follow" />
-<link rel="canonical" href="https://{{ request.get_host }}{% url 'technology-jobs' tech_slug %}" />
+<link rel="canonical" href="{{ SITE_URL }}{% url 'technology-jobs' tech_slug %}" />
 
 <meta property="og:type" content="website" />
 <meta property="og:title" content="Jobs with {{ tech_name }}" />
-<meta property="og:url" content="https://{{ request.get_host }}{% url 'technology-jobs' tech_slug %}" />
+<meta property="og:url" content="{{ SITE_URL }}{% url 'technology-jobs' tech_slug %}" />
 <meta property="og:description" content="List of jobs with {{ tech_name }}" />
-<meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+<meta property="og:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
 <meta property="og:locale" content="en_US" />
 
 <meta name="twitter:card" content="summary" />
@@ -24,7 +24,7 @@
 <meta name="twitter:site" content="@rasulkireev" />
 <meta name="twitter:title" content="Jobs with {{ tech_name }}" />
 <meta name="twitter:description" content="List of jobs with {{ tech_name }}" />
-<meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+<meta name="twitter:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
 {% endblock meta %}
 
 {% block content %}
@@ -69,10 +69,10 @@
     {
       "@type": "ListItem",
       "position": {{ forloop.counter }},
-      "url": "https://{{ request.get_host }}{% url 'post' job.id %}",
+      "url": "{{ SITE_URL }}{% url 'post' job.id %}",
       "item": {
         "@type": "JobPosting",
-        "title": "{{ job.titles.all.0.name }}",
+        "title": "{{ job.titles.all.0.name|default:'Developer'|replace_quotes }}",
         "description": "{{ job.description|safe }}",
         "datePosted": "{{ job.submitted_datetime|date:'Y-m-d' }}",
         "validThrough": "{{ job.submitted_datetime|plus_days:30|date:'Y-m-d' }}",

--- a/templates/jobs/title-jobs.html
+++ b/templates/jobs/title-jobs.html
@@ -10,13 +10,13 @@
 <meta name="description" content="List of '{{ title_name }}' jobs" />
 <meta name="keywords" content="jobs, job postings, {{ object_list.0.company.name }}, {{ title_name }}" />
 <meta name="robots" content="index, follow" />
-<link rel="canonical" href="https://{{ request.get_host }}{% url 'title-jobs' title_slug %}" />
+<link rel="canonical" href="{{ SITE_URL }}{% url 'title-jobs' title_slug %}" />
 
 <meta property="og:type" content="website" />
 <meta property="og:title" content="'{{ title_name }}' jobs" />
-<meta property="og:url" content="https://{{ request.get_host }}{% url 'title-jobs' title_slug %}" />
+<meta property="og:url" content="{{ SITE_URL }}{% url 'title-jobs' title_slug %}" />
 <meta property="og:description" content="List of '{{ title_name }}' jobs" />
-<meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+<meta property="og:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
 <meta property="og:locale" content="en_US" />
 
 <meta name="twitter:card" content="summary" />
@@ -24,7 +24,7 @@
 <meta name="twitter:site" content="@rasulkireev" />
 <meta name="twitter:title" content="'{{ title_name }}' jobs" />
 <meta name="twitter:description" content="List of '{{ title_name }}' jobs" />
-<meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+<meta name="twitter:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
 {% endblock meta %}
 
 {% block content %}
@@ -67,10 +67,10 @@
     {
       "@type": "ListItem",
       "position": {{ forloop.counter }},
-      "url": "https://{{ request.get_host }}{% url 'post' job.id %}",
+      "url": "{{ SITE_URL }}{% url 'post' job.id %}",
       "item": {
         "@type": "JobPosting",
-        "title": "{{ job.titles.all.0.name }}",
+        "title": "{{ job.titles.all.0.name|default:'Developer'|replace_quotes }}",
         "description": "{{ job.description|safe }}",
         "datePosted": "{{ job.submitted_datetime|date:'Y-m-d' }}",
         "validThrough": "{{ job.submitted_datetime|plus_days:30|date:'Y-m-d' }}",

--- a/templates/jobs/titles-with-jobs.html
+++ b/templates/jobs/titles-with-jobs.html
@@ -9,13 +9,13 @@
 <meta name="description" content="List of Tech Job Titles that are in demand right now." />
 <meta name="keywords" content="job titles, hiring, jobs" />
 <meta name="robots" content="index, follow" />
-<link rel="canonical" href="https://{{ request.get_host }}{% url 'titles' %}" />
+<link rel="canonical" href="{{ SITE_URL }}{% url 'titles' %}" />
 
 <meta property="og:type" content="website" />
 <meta property="og:title" content="Tech Job Titles that are in demand right now." />
-<meta property="og:url" content="https://{{ request.get_host }}{% url 'titles' %}" />
+<meta property="og:url" content="{{ SITE_URL }}{% url 'titles' %}" />
 <meta property="og:description" content="List of Tech Job Titles that are in demand right now." />
-<meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+<meta property="og:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
 <meta property="og:locale" content="en_US" />
 
 <meta name="twitter:card" content="summary" />
@@ -23,13 +23,13 @@
 <meta name="twitter:site" content="@rasulkireev" />
 <meta name="twitter:title" content="Tech Job Titles that are in demand right now." />
 <meta name="twitter:description" content="List of Tech Job Titles that are in demand right now." />
-<meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+<meta name="twitter:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
 {% endblock meta %}
 
 {% block content %}
 <div class="px-4 mx-auto space-y-10 max-w-7xl sm:px-6 lg:px-8">
   <div class="mx-auto max-w-2xl text-center">
-    <h1 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Tech tobs titles that are in demand right now.</h1>
+    <h1 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Tech job titles that are in demand right now.</h1>
   </div>
   <div class="mx-auto max-w-xl">
     <ul role="list" class="ml-2 list-disc list-inside">
@@ -57,7 +57,7 @@
     {
       "@type": "ListItem",
       "position": {{ forloop.counter }},
-      "url": "https://{{ request.get_host }}{% url 'title-jobs' title.slug %}",
+      "url": "{{ SITE_URL }}{% url 'title-jobs' title.slug %}",
       "item": {
         "@type": "Organization",
         "name": "{{ title.name }}"

--- a/templates/pages/privacy_policy.html
+++ b/templates/pages/privacy_policy.html
@@ -1,4 +1,21 @@
 {% extends "base.html" %}
+{% load static %}
+
+{% block meta %}
+<title>Privacy Policy | Tech Job Alerts</title>
+<meta name="description" content="Privacy policy for Tech Job Alerts, including how job alert account and usage data is collected and used." />
+<meta name="robots" content="index, follow" />
+<link rel="canonical" href="{{ SITE_URL }}{% url 'privacy' %}" />
+<meta property="og:type" content="website" />
+<meta property="og:title" content="Privacy Policy | Tech Job Alerts" />
+<meta property="og:url" content="{{ SITE_URL }}{% url 'privacy' %}" />
+<meta property="og:description" content="Privacy policy for Tech Job Alerts, including how job alert account and usage data is collected and used." />
+<meta property="og:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:title" content="Privacy Policy | Tech Job Alerts" />
+<meta name="twitter:description" content="Privacy policy for Tech Job Alerts, including how job alert account and usage data is collected and used." />
+<meta name="twitter:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
+{% endblock meta %}
 
 {% block content %}
 <div class="mx-auto prose max-w-7xl">

--- a/templates/pages/support.html
+++ b/templates/pages/support.html
@@ -1,10 +1,25 @@
-{% extends 'base.html' %}
+{% extends "base.html" %}
 {% load markdown_extras %}
+{% load static %}
 {% load widget_tweaks %}
 
+{% block meta %}
+<title>Support | Tech Job Alerts</title>
+<meta name="description" content="Contact Tech Job Alerts support for bugs, suggestions, or product questions." />
+<meta name="robots" content="index, follow" />
+<link rel="canonical" href="{{ SITE_URL }}{% url 'support' %}" />
+<meta property="og:type" content="website" />
+<meta property="og:title" content="Support | Tech Job Alerts" />
+<meta property="og:url" content="{{ SITE_URL }}{% url 'support' %}" />
+<meta property="og:description" content="Contact Tech Job Alerts support for bugs, suggestions, or product questions." />
+<meta property="og:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:title" content="Support | Tech Job Alerts" />
+<meta name="twitter:description" content="Contact Tech Job Alerts support for bugs, suggestions, or product questions." />
+<meta name="twitter:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
+{% endblock meta %}
+
 {% block content %}
-
-
 <div class="max-w-4xl p-4 mx-auto border rounded-md">
   <div class="my-2 text-center">
     <h1 class="text-xl font-bold tracking-tight text-gray-900 sm:text-6xl">Support Form</h1>

--- a/templates/pages/tos.html
+++ b/templates/pages/tos.html
@@ -1,4 +1,21 @@
 {% extends "base.html" %}
+{% load static %}
+
+{% block meta %}
+<title>Terms of Service | Tech Job Alerts</title>
+<meta name="description" content="Terms of service for Tech Job Alerts, including website use, accounts, limitations, and contact details." />
+<meta name="robots" content="index, follow" />
+<link rel="canonical" href="{{ SITE_URL }}{% url 'tos' %}" />
+<meta property="og:type" content="website" />
+<meta property="og:title" content="Terms of Service | Tech Job Alerts" />
+<meta property="og:url" content="{{ SITE_URL }}{% url 'tos' %}" />
+<meta property="og:description" content="Terms of service for Tech Job Alerts, including website use, accounts, limitations, and contact details." />
+<meta property="og:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:title" content="Terms of Service | Tech Job Alerts" />
+<meta name="twitter:description" content="Terms of service for Tech Job Alerts, including website use, accounts, limitations, and contact details." />
+<meta name="twitter:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
+{% endblock meta %}
 
 {% block content %}
 <div class="mx-auto prose max-w-7xl">

--- a/templates/pages/uses.html
+++ b/templates/pages/uses.html
@@ -6,19 +6,19 @@
     <meta name="description" content="Technologies and Tools Used by Tech Job Alerts" />
     <meta name="keywords" content="Tech Job Alerts, Technology Stack, Web Development" />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://{{ request.get_host }}/uses" />
+    <link rel="canonical" href="{{ SITE_URL }}/uses" />
     <meta property="og:type" content="article" />
     <meta property="og:title" content="Technologies We Use | Tech Job Alerts" />
-    <meta property="og:url" content="https://{{ request.get_host }}/uses" />
+    <meta property="og:url" content="{{ SITE_URL }}/uses" />
     <meta property="og:description" content="Technologies and Tools Used by Tech Job Alerts" />
     <meta property="og:locale" content="en_US" />
-    <meta property="og:image" content="https://osig.app/g?site=meta&style=logo&font=markerfelt&title=Tech Job Alerts&subtitle=Tech we use&image_url=https://osig.app/g?site=x&style=logo&font=markerfelt&title=Tech Job Alerts&subtitle=Tech we use!&image_url=https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+    <meta property="og:image" content="https://osig.app/g?site=meta&style=logo&font=markerfelt&title=Tech Job Alerts&subtitle=Tech we use&image_url=https://osig.app/g?site=x&style=logo&font=markerfelt&title=Tech Job Alerts&subtitle=Tech we use!&image_url={{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:creator" content="@rasulkireev" />
     <meta name="twitter:site" content="@rasulkireev" />
     <meta name="twitter:title" content="Technologies We Use | Tech Job Alerts" />
     <meta name="twitter:description" content="Technologies and Tools Used by Tech Job Alerts" />
-    <meta name="twitter:image" content="https://osig.app/g?site=x&style=logo&font=markerfelt&title=Tech Job Alerts&subtitle=Tech we use&image_url=https://osig.app/g?site=x&style=logo&font=markerfelt&title=Tech Job Alerts&subtitle=Tech we use!&image_url=https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+    <meta name="twitter:image" content="https://osig.app/g?site=x&style=logo&font=markerfelt&title=Tech Job Alerts&subtitle=Tech we use&image_url=https://osig.app/g?site=x&style=logo&font=markerfelt&title=Tech Job Alerts&subtitle=Tech we use!&image_url={{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
 {% endblock meta %}
 
 {% block content %}

--- a/templates/robots.txt
+++ b/templates/robots.txt
@@ -1,2 +1,11 @@
 User-Agent: *
 Disallow: /admin/
+Disallow: /admin-panel/
+Disallow: /api/
+Disallow: /jobs/create-alert/
+Disallow: /jobs/create-custom-alert/
+Disallow: /jobs/confirm/
+Disallow: /jobs/digest/
+Disallow: /jobs/unsubscribe/
+
+Sitemap: {{ SITE_URL }}/sitemap.xml

--- a/templates/socialaccount/login.html
+++ b/templates/socialaccount/login.html
@@ -2,6 +2,11 @@
 {% load widget_tweaks %}
 {% load socialaccount %}
 
+{% block meta %}
+<title>Social Login | Tech Job Alerts</title>
+<meta name="robots" content="noindex, follow" />
+{% endblock meta %}
+
 {% block content %}
 
     <div class="px-6 mx-auto max-w-7xl">

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -1,0 +1,17 @@
+from django.test import SimpleTestCase, override_settings
+
+from hn_jobs.utils import build_absolute_site_url, site_metadata
+
+
+class SiteMetadataTests(SimpleTestCase):
+    @override_settings(SITE_URL="https://example.com")
+    def test_build_absolute_site_url_uses_configured_host(self):
+        assert build_absolute_site_url("/jobs/") == "https://example.com/jobs/"
+
+    @override_settings(SITE_URL="https://example.com")
+    def test_build_absolute_site_url_normalizes_relative_paths(self):
+        assert build_absolute_site_url("jobs/") == "https://example.com/jobs/"
+
+    @override_settings(SITE_URL="https://example.com")
+    def test_site_metadata_exposes_site_url_to_templates(self):
+        assert site_metadata(None)["SITE_URL"] == "https://example.com"


### PR DESCRIPTION
## Summary
- Add a configured `SITE_URL` and use it for canonical, Open Graph, Twitter, and JSON-LD URLs instead of request host-derived URLs.
- Fill missing metadata for blog/legal/support/auth pages and fix the empty `/jobs/` canonical.
- Expand sitemap coverage for static pages, recent jobs, company/technology/title landing pages, and highest-paid listicles.
- Add sitemap discovery and crawler exclusions to `robots.txt`.
- Point title/technology chips at clean landing pages and fix JobPosting schema title fallbacks.

## Why
The SEO audit found that several public pages inherited the homepage canonical, `/jobs/` rendered an empty canonical, and the sitemap omitted most indexable landing pages. Those issues could suppress indexation and dilute ranking signals.

## Validation
- `git diff --check`
- `uvx ruff check hn_jobs/settings/base.py hn_jobs/settings/production.py hn_jobs/sitemaps.py hn_jobs/utils.py jobs/views.py utils/tests.py`
- `ENVIRONMENT=local ... .venv/bin/python manage.py check` passed with existing warning: missing `frontend/build` static directory.
- `ENVIRONMENT=local ... .venv/bin/python manage.py test utils.tests jobs.tests --verbosity 2` passed 5 tests with existing warnings: missing `frontend/build` and a pre-existing invalid escape sequence in `jobs/tasks.py`.