### PR TITLE
[CI] Fix GHCR Image Tag Casing

### DIFF
--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -26,13 +26,18 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
 
+      - name: Set image name
+        id: image
+        shell: bash
+        run: echo "name=ghcr.io/${GITHUB_REPOSITORY,,}-workers" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
           context: .
           push: true
           file: deployment/Dockerfile.workers
-          tags: ghcr.io/${{ github.repository }}-workers
+          tags: ${{ steps.image.outputs.name }}
 
       - name: Deploy to CapRover
         uses: caprover/deploy-from-github@main
@@ -40,4 +45,4 @@ jobs:
           server: ${{ secrets.CAPROVER_SERVER }}
           app: ${{ env.PROJECT_NAME }}-workers
           token: '${{ secrets.WORKERS_APP_TOKEN }}'
-          image: ghcr.io/${{ github.repository }}-workers
+          image: ${{ steps.image.outputs.name }}

--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
+      - name: Login to GHCR
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -32,7 +32,7 @@ jobs:
         run: echo "name=ghcr.io/${GITHUB_REPOSITORY,,}-workers" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,13 +26,18 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
 
+      - name: Set image name
+        id: image
+        shell: bash
+        run: echo "name=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
           context: .
           push: true
           file: deployment/Dockerfile.server
-          tags: ghcr.io/${{ github.repository }}
+          tags: ${{ steps.image.outputs.name }}
 
       - name: Deploy to CapRover
         uses: caprover/deploy-from-github@main
@@ -40,4 +45,4 @@ jobs:
             server: ${{ secrets.CAPROVER_SERVER }}
             app: ${{ env.PROJECT_NAME }}
             token: '${{ secrets.APP_TOKEN }}'
-            image: ghcr.io/${{ github.repository }}
+            image: ${{ steps.image.outputs.name }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
+      - name: Login to GHCR
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -32,7 +32,7 @@ jobs:
         run: echo "name=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary
- normalize GHCR image names to lowercase before Docker Buildx receives them
- reuse the computed image name for both push and CapRover deploy steps
- apply the same fix to server and worker deploy workflows
- update deploy workflow action versions to current stable majors to avoid the Node 20 action deprecation warning seen in the failed run

## Verification
- parsed both GitHub Actions workflow YAML files with PyYAML
- verified Bash lowercasing yields ghcr.io/lvtd-llc/tjalerts and ghcr.io/lvtd-llc/tjalerts-workers
- ran Docker Buildx --check for server and worker Dockerfiles with the lowercase tags
- built the worker Docker image locally with tag ghcr.io/lvtd-llc/tjalerts-workers without pushing
- pre-commit hooks passed during both commits
- Greptile reviewed the current head commit with Confidence Score: 5/5 and zero review threads

## Notes
- This repo does not report PR checks for this branch; the deploy workflows are configured for pushes to main, so the actual production deploy rerun will happen after merge.