### PR TITLE
[Jobs] Skip Non-Hiring HN Comments

### DIFF
--- a/jobs/tasks.py
+++ b/jobs/tasks.py
@@ -27,7 +27,14 @@ from jobs.choices import PostSource
 from jobs.enrichment import augment_cleaned_job_data_with_context, build_reader_context, extract_first_url
 from jobs.filters import PostFilter
 from jobs.models import Alert, AlertEmailSend, Company, Email, Post, Technology, Title
-from jobs.utils import clean_job_json_object, fix_email, get_embedding, has_number, is_generic
+from jobs.utils import (
+    clean_job_json_object,
+    fix_email,
+    get_embedding,
+    has_number,
+    is_generic,
+    is_probably_non_hiring_hn_comment,
+)
 
 logger = get_tjalerts_logger(__name__)
 
@@ -300,6 +307,10 @@ def analyze_hn_page(who_is_hiring_id, who_is_hiring_title, comment_id):
             return "Comment was deleted"
     except KeyError:
         pass
+
+    if is_probably_non_hiring_hn_comment(json_job.get("text", "")):
+        logger.info("Skipping non-hiring HN comment", comment_id=comment_id)
+        return "Comment is not a company hiring post"
 
     who_is_hiring_comment_id = int(json_job["id"])
     if (

--- a/jobs/tests.py
+++ b/jobs/tests.py
@@ -24,7 +24,7 @@ from jobs.tasks import (
     import_remote_ok_jobs,
     merge_company_emails,
 )
-from jobs.utils import clean_job_json_object
+from jobs.utils import clean_job_json_object, is_probably_non_hiring_hn_comment, normalize_hn_comment_text
 
 
 class CompanyEmailMergeTests(SimpleTestCase):
@@ -322,3 +322,180 @@ class ReaderContextTests(SimpleTestCase):
         assert "untrusted data" in messages[0]["content"]
         assert "<untrusted_page_content>" in messages[1]["content"]
         assert "</untrusted_page_content>" in messages[1]["content"]
+
+
+class HNCommentHiringDetectionTests(SimpleTestCase):
+    def test_detects_who_wants_to_be_hired_style_comment(self):
+        comment = """
+        SEEKING WORK | Full-Stack Developer (Django, Vue, AWS)<p>
+        Location: Argentina (remote-friendly, US/EU time overlap)<p>
+        I'm a full-stack developer with a background in finance.<p>
+        GitHub: https://github.com/lorenzoreyes<p>
+        Email: lorenzoreyesx@gmail.com
+        """
+
+        assert is_probably_non_hiring_hn_comment(comment) is True
+
+    def test_detects_self_promotional_profile_without_hiring_signal(self):
+        comment = """
+        I'm a backend engineer with 8 years of Python experience.<p>
+        Portfolio: https://example.com<p>
+        Email: person@example.com
+        """
+
+        assert is_probably_non_hiring_hn_comment(comment) is True
+
+    def test_detects_self_promotional_profile_with_seniority_and_specialization(self):
+        comment = """
+        I'm a senior backend engineer with 10 years of Python experience.<p>
+        GitHub: https://github.com/person<p>
+        Email: person@example.com
+        """
+
+        assert is_probably_non_hiring_hn_comment(comment) is True
+
+    def test_detects_self_promotional_profile_with_staff_data_title(self):
+        comment = """
+        I am a staff data scientist focused on NLP and forecasting.<p>
+        Portfolio: https://example.com<p>
+        Email: person@example.com
+        """
+
+        assert is_probably_non_hiring_hn_comment(comment) is True
+
+    def test_detects_pipe_separated_seeking_work_header(self):
+        comment = """
+        Austin, TX | Python Developer | SEEKING WORK | Remote<p>
+        Django, FastAPI, Postgres, AWS<p>
+        GitHub: https://github.com/person
+        """
+
+        assert is_probably_non_hiring_hn_comment(comment) is True
+
+    def test_career_singular_is_not_a_company_hiring_signal(self):
+        comment = """
+        I'm a backend engineer and throughout my career I have built payments systems.<p>
+        GitHub: https://github.com/person<p>
+        Email: person@example.com
+        """
+
+        assert is_probably_non_hiring_hn_comment(comment) is True
+
+    def test_apply_without_application_context_is_not_a_company_hiring_signal(self):
+        comment = """
+        I'm a full-stack developer and I apply accessibility best practices daily.<p>
+        Portfolio: https://example.com<p>
+        Email: person@example.com
+        """
+
+        assert is_probably_non_hiring_hn_comment(comment) is True
+
+    def test_join_the_team_without_qualifier_is_not_a_company_hiring_signal(self):
+        comment = """
+        I'm a backend engineer interested in distributed systems and would love to join the team.<p>
+        Portfolio: https://example.com<p>
+        Email: person@example.com
+        """
+
+        assert is_probably_non_hiring_hn_comment(comment) is True
+
+    def test_market_commentary_is_not_a_company_hiring_signal(self):
+        comment = """
+        I'm a backend engineer with Python and Postgres experience. The market is hiring again, but selectively.<p>
+        Portfolio: https://example.com<p>
+        Email: person@example.com
+        """
+
+        assert is_probably_non_hiring_hn_comment(comment) is True
+
+    def test_allows_company_hiring_comment(self):
+        comment = """
+        Acme AI | Staff Backend Engineer | Remote (US) | Full-time<p>
+        We're hiring engineers to build infrastructure for our payments platform.
+        Apply at https://example.com/careers/backend-engineer
+        """
+
+        assert is_probably_non_hiring_hn_comment(comment) is False
+
+    def test_allows_company_looking_for_engineers_comment(self):
+        comment = """
+        ExampleCo | Berlin | Onsite<p>
+        We are looking for a full-stack developer to join our product team.
+        Send your resume to jobs@example.com.
+        """
+
+        assert is_probably_non_hiring_hn_comment(comment) is False
+
+    def test_allows_company_post_with_work_life_balance_phrase(self):
+        comment = """
+        Acme AI | Remote<p>
+        We are seeking work-life balance minded engineers for our infrastructure team.
+        """
+
+        assert is_probably_non_hiring_hn_comment(comment) is False
+
+    def test_allows_first_person_company_post_with_qualified_team_signal(self):
+        comment = """
+        Acme AI | Remote<p>
+        I'm a senior backend engineer at Acme, and we need another engineer to join our platform team.<p>
+        Email: jobs@example.com
+        """
+
+        assert is_probably_non_hiring_hn_comment(comment) is False
+
+    def test_allows_first_person_company_post_with_company_is_hiring_signal(self):
+        comment = """
+        Acme AI | Remote<p>
+        I'm a backend engineer at Acme. Our company is hiring another platform engineer.<p>
+        Email: jobs@example.com
+        """
+
+        assert is_probably_non_hiring_hn_comment(comment) is False
+
+    def test_allows_first_person_company_post_with_looking_for_signal(self):
+        comment = """
+        Acme AI | Remote<p>
+        I'm a senior engineer at Acme. We are looking for a junior developer.<p>
+        Email: jobs@example.com
+        """
+
+        assert is_probably_non_hiring_hn_comment(comment) is False
+
+    def test_allows_first_person_company_post_with_need_role_signal(self):
+        comment = """
+        Acme AI | Remote<p>
+        I'm a staff engineer at Acme. We need another backend engineer for the payments group.<p>
+        Email: jobs@example.com
+        """
+
+        assert is_probably_non_hiring_hn_comment(comment) is False
+
+    def test_allows_first_person_company_post_with_need_plural_role_signal(self):
+        comment = """
+        Acme AI | Remote<p>
+        I'm a staff engineer at Acme. We need backend engineers for the payments group.<p>
+        Email: jobs@example.com
+        """
+
+        assert is_probably_non_hiring_hn_comment(comment) is False
+
+    def test_allows_first_person_company_post_with_seeking_role_signal(self):
+        comment = """
+        Acme AI | Remote<p>
+        I'm a senior engineer at Acme. We are seeking another backend developer.<p>
+        Email: jobs@example.com
+        """
+
+        assert is_probably_non_hiring_hn_comment(comment) is False
+
+    def test_allows_first_person_company_post_with_seeking_plural_role_signal(self):
+        comment = """
+        Acme AI | Remote<p>
+        I'm a senior engineer at Acme. We are seeking backend developers.<p>
+        Email: jobs@example.com
+        """
+
+        assert is_probably_non_hiring_hn_comment(comment) is False
+
+    def test_normalizes_hacker_news_html(self):
+        assert normalize_hn_comment_text("Hello<p>Remote &amp; onsite<br>Apply") == "Hello\nRemote & onsite\nApply"

--- a/jobs/utils.py
+++ b/jobs/utils.py
@@ -1,10 +1,12 @@
 import re
 from datetime import datetime
+from html import unescape
 from itertools import combinations
 
 from allauth.account.models import EmailAddress
 from django.conf import settings
 from django.db.models import Count, Q
+from django.utils.html import strip_tags
 from openai import OpenAI
 
 from hn_jobs.utils import get_tjalerts_logger
@@ -39,6 +41,105 @@ list_of_expected_keys = [
     "years_of_experience",
     "levels_of_experience",
 ]
+
+
+NON_HIRING_COMMENT_OPENING_PATTERNS = [
+    r"\bseeking\s+work(?![-/\w])",
+    r"\blooking\s+for\s+work(?![-/\w])",
+    r"\bavailable\s+for\s+hire\b",
+    r"\bopen\s+to\s+work\b",
+    r"\bhire\s+me\b",
+    (r"\bseeking\s+" r"(?:employment|a\s+(?:job|role|position)|remote\s+work|contract\s+work|freelance\s+work)\b"),
+    (
+        r"\blooking\s+for\s+"
+        r"(?:employment|a\s+(?:job|role|position)|remote\s+work|contract\s+work|"
+        r"freelance\s+work|new\s+(?:role|position|opportunity))\b"
+    ),
+]
+
+NON_HIRING_COMMENT_BODY_PATTERNS = [
+    r"\bwho wants to be hired\b",
+    r"\bposted (?:this )?(?:in|on) the wrong thread\b",
+    r"\bshould (?:be|go) (?:in|on) the (?:who wants to be hired|freelancer|seeking work) thread\b",
+    r"\bmy\s+(?:resume|r\u00e9sum\u00e9|cv)\b",
+]
+
+SELF_PROMOTION_TITLE_PATTERN = (
+    r"(?:(?:junior|mid[- ]level|midlevel|mid|senior|staff|principal|lead|founding|experienced)\s+)?"
+    r"(?:full[- ]stack|frontend|front[- ]end|backend|back[- ]end|software|data|mobile|"
+    r"devops|machine learning|ml|ai)?\s*"
+    r"(?:engineer|developer|designer|scientist)"
+)
+
+SELF_PROMOTION_PATTERNS = [
+    r"\bi(?:'|\u2019)?m\s+(?:an?\s+)?" + SELF_PROMOTION_TITLE_PATTERN + r"\b",
+    r"\bi am\s+(?:an?\s+)?" + SELF_PROMOTION_TITLE_PATTERN + r"\b",
+]
+
+CONTACT_MARKER_PATTERNS = [
+    r"\bgithub\s*:",
+    r"\blinkedin\s*:",
+    r"\bportfolio\s*:",
+    r"\bemail\s*:",
+]
+
+COMPANY_HIRING_ROLE_PATTERN = (
+    r"(?:engineers?|developers?|devs?|designers?|scientists?|managers?|leads?|contractors?|"
+    r"consultants?|candidates?|persons?|people)"
+)
+
+COMPANY_HIRING_SIGNAL_PATTERNS = [
+    r"\b(?:we(?:'|\u2019)?re|we are|our team is)\s+hiring\b",
+    r"\b(?:my|our)\s+company\s+(?:is|are)\s+hiring\b",
+    r"\bwe(?:'|\u2019)?re\s+looking\s+for\b",
+    r"\bwe are\s+looking\s+for\b",
+    r"\bwe(?:'|\u2019)?re\s+seeking\s+(?:(?:an?|another)\s+)?(?:[\w-]+\s+){0,4}" + COMPANY_HIRING_ROLE_PATTERN + r"\b",
+    r"\bwe are\s+seeking\s+(?:(?:an?|another)\s+)?(?:[\w-]+\s+){0,4}" + COMPANY_HIRING_ROLE_PATTERN + r"\b",
+    r"\bwe need\s+(?:an?\s+)?(?:[\w-]+\s+){0,4}" + COMPANY_HIRING_ROLE_PATTERN + r"\b",
+    r"\bwe need\s+(?:someone|somebody|people|folks|candidates?)\b",
+    r"\bopen roles?\b",
+    r"\bpositions?\s+(?:available|open)\b",
+    r"\bapply\s+(?:at|now|here|online|directly|via|through|below)\b",
+    r"\bcareers\s*(?::|/)",
+    r"\bcareers\s+(?:at|page|portal|site)\b",
+    r"/careers(?:/|\b)",
+    r"\bjoin our(?:\s+[\w-]+){0,3}\s+team\b",
+    r"\bjoin the(?:\s+[\w-]+){1,3}\s+team\b",
+]
+
+OPENING_COMMENT_LINE_COUNT = 4
+
+
+def normalize_hn_comment_text(text: str) -> str:
+    text = re.sub(r"(?i)<\s*(?:p|br)\s*/?>", "\n", text or "")
+    text = strip_tags(text)
+    text = unescape(text)
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"\s*\n\s*", "\n", text)
+    return text.strip()
+
+
+def is_probably_non_hiring_hn_comment(text: str) -> bool:
+    normalized_text = normalize_hn_comment_text(text)
+    if not normalized_text:
+        return True
+
+    lowercase_text = normalized_text.lower()
+    compact_text = re.sub(r"\s+", " ", lowercase_text)
+    opening_lines = "\n".join(lowercase_text.splitlines()[:OPENING_COMMENT_LINE_COUNT])
+    opening_text = re.sub(r"\s+", " ", opening_lines)
+
+    if any(re.search(pattern, opening_text) for pattern in NON_HIRING_COMMENT_OPENING_PATTERNS):
+        return True
+
+    if any(re.search(pattern, compact_text) for pattern in NON_HIRING_COMMENT_BODY_PATTERNS):
+        return True
+
+    has_self_promotion = any(re.search(pattern, compact_text) for pattern in SELF_PROMOTION_PATTERNS)
+    has_contact_marker = any(re.search(pattern, compact_text) for pattern in CONTACT_MARKER_PATTERNS)
+    has_company_hiring_signal = any(re.search(pattern, compact_text) for pattern in COMPANY_HIRING_SIGNAL_PATTERNS)
+
+    return has_self_promotion and has_contact_marker and not has_company_hiring_signal
 
 
 def clean_job_json_object(original_comment: dict, nlp_data: dict) -> dict:

--- a/snippets/review_hn_non_hiring_posts.py
+++ b/snippets/review_hn_non_hiring_posts.py
@@ -1,0 +1,98 @@
+from django.db import transaction
+from django.utils import timezone
+from tqdm import tqdm
+
+from jobs.choices import PostSource
+from jobs.models import Post
+from jobs.utils import is_probably_non_hiring_hn_comment, normalize_hn_comment_text
+
+
+valid_actions = {"dry_run", "mark", "delete"}
+action = (input("Action [dry_run/mark/delete]: ").strip() or "dry_run").lower()
+
+if action not in valid_actions:
+    raise ValueError(f"Action must be one of: {', '.join(sorted(valid_actions))}")
+
+if action == "delete":
+    confirmation = input("Type DELETE_NON_HIRING_HN_POSTS to hard-delete matching posts: ").strip()
+    if confirmation != "DELETE_NON_HIRING_HN_POSTS":
+        raise ValueError("Delete confirmation did not match.")
+
+queryset = (
+    Post.objects.filter(source=PostSource.HACKER_NEWS)
+    .select_related("company")
+    .only(
+        "id",
+        "company",
+        "company__name",
+        "source_external_id",
+        "source_payload",
+        "source_url",
+        "original_text",
+        "who_is_hiring_comment_id",
+    )
+)
+
+matched_count = 0
+marked_count = 0
+deleted_count = 0
+empty_text_count = 0
+already_marked_count = 0
+processed_count = 0
+detected_at = timezone.now().isoformat()
+
+with tqdm(total=queryset.count(), desc="Reviewing HN posts") as progress:
+    for post in queryset.iterator(chunk_size=500):
+        processed_count += 1
+        payload = post.source_payload if isinstance(post.source_payload, dict) else {}
+        original_text = post.original_text or payload.get("text", "")
+
+        if not normalize_hn_comment_text(original_text):
+            empty_text_count += 1
+            progress.update(1)
+            continue
+
+        if not is_probably_non_hiring_hn_comment(original_text):
+            progress.update(1)
+            continue
+
+        matched_count += 1
+        comment_id = post.source_external_id or post.who_is_hiring_comment_id or post.id
+        company_name = post.company.name if post.company_id else ""
+        tqdm.write(f"Matched post={post.id} comment={comment_id} company={company_name} url={post.source_url}")
+
+        if action == "mark":
+            review = payload.get("non_hiring_review", {})
+            if review.get("detected") is True:
+                already_marked_count += 1
+                progress.update(1)
+                continue
+
+            payload["non_hiring_review"] = {
+                "detected": True,
+                "detected_at": detected_at,
+                "detector": "jobs.utils.is_probably_non_hiring_hn_comment",
+                "action": "mark",
+            }
+            post.source_payload = payload
+            post.save(update_fields=["source_payload"])
+            marked_count += 1
+
+        if action == "delete":
+            with transaction.atomic():
+                post.delete()
+            deleted_count += 1
+
+        progress.update(1)
+
+print(
+    {
+        "action": action,
+        "processed": processed_count,
+        "matched": matched_count,
+        "marked": marked_count,
+        "already_marked": already_marked_count,
+        "deleted": deleted_count,
+        "empty_text_skipped": empty_text_count,
+    }
+)


### PR DESCRIPTION
## Summary
- Skip obvious candidate/self-promotional Hacker News comments before embedding and OpenAI job extraction.
- Normalize HN comment HTML before deterministic detection.
- Add coverage for wrong-thread candidate posts, pipe-separated SEEKING WORK headers, seniority-qualified candidate titles, and valid company hiring posts.
- Add a shell snippet for reviewing existing Hacker News posts and dry-running, marking, or deleting detected non-hiring posts.

## Why
Some users post “Who wants to be hired” style comments in “Who is hiring” threads. Those comments were being processed as job posts, creating noisy company records and wasting extraction calls.

## Validation
- `pre-commit run --files jobs/utils.py jobs/tests.py jobs/tasks.py`
- `poetry run python manage.py test jobs.tests --verbosity 2` against Postgres/pgvector on port 55432 (36 tests)
- `pre-commit run --files snippets/review_hn_non_hiring_posts.py`
- `poetry run python -m py_compile snippets/review_hn_non_hiring_posts.py`
