### PR TITLE
Fix missing allauth email address handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 **Security** in case of vulnerabilities.
 
 ## Unreleased
+### Fixed
+- Prevented missing allauth email address records from crashing settings/email verification paths or sending non-serializable exception objects to Sentry logging.
+
 ### Changed
 - Updated OpenAI model defaults for HN job extraction to `gpt-5.4-nano`, salary parsing to `gpt-5-nano`, and made chat/embedding model names configurable via Django settings.
 - Removed the unsafe btree index on `Company.emails` and bounded the denormalized company email summary to prevent oversized index-row errors during HN job analysis.

--- a/hn_jobs/tests.py
+++ b/hn_jobs/tests.py
@@ -1,8 +1,36 @@
 from unittest.mock import patch
 
-from django.test import SimpleTestCase
+from allauth.account.models import EmailAddress
+from django.test import SimpleTestCase, TestCase
 
 from hn_jobs.sitemaps import HighestPaidJobsListicleSitemap
+from hn_jobs.utils import add_users_context
+from users.models import CustomUser
+
+
+class UserContextTests(TestCase):
+    def test_add_users_context_defaults_unverified_when_email_address_is_missing(self):
+        user = CustomUser.objects.create_user(username="missing-email", email="missing@example.com")
+        context = {}
+
+        with patch("hn_jobs.utils.logger.warning") as warning_mock:
+            add_users_context(context, user)
+
+        assert context["email_verified"] is False
+        warning_mock.assert_called_once_with(
+            "Email address record missing",
+            user_id=user.id,
+            email="missing@example.com",
+        )
+
+    def test_add_users_context_uses_email_address_verification_state(self):
+        user = CustomUser.objects.create_user(username="verified-email", email="verified@example.com")
+        EmailAddress.objects.create(user=user, email=user.email, primary=True, verified=True)
+        context = {}
+
+        add_users_context(context, user)
+
+        assert context["email_verified"] is True
 
 
 class SitemapTests(SimpleTestCase):

--- a/hn_jobs/utils.py
+++ b/hn_jobs/utils.py
@@ -52,8 +52,9 @@ def site_metadata(request):
 def add_users_context(context, user, self=None):
     try:
         context["email_verified"] = EmailAddress.objects.get_for_user(user, user.email).verified
-    except EmailAddress.DoesNotExist as e:
-        logger.warning("Email Error", error=e)
+    except EmailAddress.DoesNotExist:
+        context["email_verified"] = False
+        logger.warning("Email address record missing", user_id=user.id, email=user.email)
 
     if self:
         alias_request_user(self.request)

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,1 +1,48 @@
-# Create your tests here.
+from unittest.mock import Mock, patch
+
+from allauth.account.models import EmailAddress
+from django.test import RequestFactory, TestCase
+
+from users.models import CustomUser
+from users.views import get_or_create_user_email_address, resend_email_confirmation_email
+
+
+class EmailConfirmationResendTests(TestCase):
+    def test_resend_confirmation_creates_missing_email_address_record(self):
+        user = CustomUser.objects.create_user(username="missing-email", email="missing@example.com")
+        request = RequestFactory().get("/users/send-confirmation")
+        request.user = user
+        adapter = Mock()
+
+        with (
+            patch("users.views.get_adapter", return_value=adapter),
+            patch("users.views.capture_request_event") as capture_event_mock,
+            patch("users.views.logger.warning") as warning_mock,
+        ):
+            response = resend_email_confirmation_email(request)
+
+        emailaddress = EmailAddress.objects.get(user=user, email=user.email)
+        assert emailaddress.primary is True
+        assert emailaddress.verified is False
+        adapter.send_confirmation_mail.assert_called_once_with(request, emailaddress, signup=False)
+        capture_event_mock.assert_called_once_with(
+            request,
+            "email confirmation resent",
+            properties={"email_verified": False},
+        )
+        warning_mock.assert_called_once_with(
+            "Email address record created for confirmation resend",
+            user_id=user.id,
+            email="missing@example.com",
+        )
+        assert response.status_code == 302
+
+    def test_missing_email_address_record_is_not_primary_when_user_already_has_primary_email(self):
+        user = CustomUser.objects.create_user(username="changed-email", email="new@example.com")
+        EmailAddress.objects.create(user=user, email="old@example.com", primary=True, verified=True)
+
+        emailaddress = get_or_create_user_email_address(user)
+
+        assert emailaddress.email == "new@example.com"
+        assert emailaddress.primary is False
+        assert emailaddress.verified is False

--- a/users/views.py
+++ b/users/views.py
@@ -15,6 +15,20 @@ from .models import CustomUser
 logger = get_tjalerts_logger(__name__)
 
 
+def get_or_create_user_email_address(user):
+    has_primary_email = EmailAddress.objects.filter(user=user, primary=True).exists()
+    emailaddress, created = EmailAddress.objects.get_or_create(
+        user=user,
+        email=user.email,
+        defaults={"primary": not has_primary_email, "verified": False},
+    )
+
+    if created:
+        logger.warning("Email address record created for confirmation resend", user_id=user.id, email=user.email)
+
+    return emailaddress
+
+
 class UserSettingsView(LoginRequiredMixin, SuccessMessageMixin, UpdateView):
     login_url = "account_login"
     model = CustomUser
@@ -49,7 +63,7 @@ def resend_email_confirmation_email(request):
     user = request.user
 
     adapter = get_adapter(request)
-    emailaddress = EmailAddress.objects.get_for_user(user, user.email)
+    emailaddress = get_or_create_user_email_address(user)
 
     adapter.send_confirmation_mail(request, emailaddress, signup=False)
     capture_request_event(request, "email confirmation resent", properties={"email_verified": emailaddress.verified})


### PR DESCRIPTION
## Summary
- Default missing allauth EmailAddress rows to unverified without logging exception objects into structured Sentry payloads
- Create a missing EmailAddress row when users request a confirmation resend
- Add regression coverage for missing EmailAddress context and resend behavior
- Update CHANGELOG.md

## Verification
- uv run --python 3.13 python -m compileall hn_jobs/utils.py hn_jobs/tests.py users/views.py users/tests.py
- ENVIRONMENT=test SECRET_KEY=test DEBUG=true ALLOWED_HOSTS=localhost,127.0.0.1 CSRF_TRUSTED_ORIGINS=http://localhost DATABASE_URL=sqlite:///test.sqlite3 REDIS_URL=redis://localhost:6379/0 OPENAI_API_KEY=test API_TOKEN=test BUTTONDOWN_API_TOKEN=test ADMIN_KEY=test MJML_SECRET=test MAILGUN_API_KEY= POSTHOG_ENABLED=false SENTRY_DSN= AWS_S3_ENDPOINT_URL=http://localhost:9000 AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test uv run --python 3.13 python manage.py check

## Local test limitation
- Full Django tests could not run locally because Docker/Postgres tooling is unavailable in this runtime, and the app's pgvector migration fails under SQLite: jobs.0023_post_vector_index errors near WITH.