### PR TITLE
fix: avoid set-valued log attributes

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -225,7 +225,7 @@ def get_title_details(request, id: str):
     if title:
         title["id"] = str(title["id"])
 
-    logger.info("get_technologies_details", duration=round(time.time() - start_time, 2))
+    logger.info("get_title_details", duration=round(time.time() - start_time, 2))
 
     return title
 

--- a/api/views.py
+++ b/api/views.py
@@ -188,7 +188,7 @@ def get_technologies_details(request, id: str):
     if technology:
         technology["id"] = str(technology["id"])
 
-    logger.info("get_technologies_details", duration={round(time.time() - start_time, 2)})
+    logger.info("get_technologies_details", duration=round(time.time() - start_time, 2))
 
     return technology
 
@@ -225,7 +225,7 @@ def get_title_details(request, id: str):
     if title:
         title["id"] = str(title["id"])
 
-    logger.info("get_technologies_details", duration={round(time.time() - start_time, 2)})
+    logger.info("get_technologies_details", duration=round(time.time() - start_time, 2))
 
     return title
 

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -355,7 +355,7 @@ class AlertCreateView(SuccessMessageMixin, CreateView):
             return response
 
         except IntegrityError as e:
-            logger.error("IntegrityError in AlertCreateView", error={str(e)})
+            logger.error("IntegrityError in AlertCreateView", error=str(e))
             capture_request_event(
                 self.request,
                 "alert creation failed",
@@ -365,7 +365,7 @@ class AlertCreateView(SuccessMessageMixin, CreateView):
             return redirect("home")
         except Exception as e:
             messages.add_message(self.request, messages.ERROR, "An unexpected error occurred. Please try again.")
-            logger.error("Exception in AlertCreateView", error={str(e)})
+            logger.error("Exception in AlertCreateView", error=str(e))
             capture_request_event(
                 self.request,
                 "alert creation failed",


### PR DESCRIPTION
## Summary
- fix accidental Python set literals in structured log attributes
- keep OpenTelemetry/PostHog log export values scalar-serializable

## Context
Sentry issue: https://rasulkireev.sentry.io/issues/7520591755/

The reported value `{0.02}` matches `duration={round(...)}` in API logging; OTLP rejects sets while encoding log attributes.

## Verification
- `python3` AST check: no set literals in logger keyword attributes across `api`, `jobs`, and `hn_jobs`
- `uv run --python 3.13 ... python`: touched files parse successfully
