### PR TITLE
fix: harden observability telemetry exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - Updated OpenAI model defaults for HN job extraction to `gpt-5.4-nano`, salary parsing to `gpt-5-nano`, and made chat/embedding model names configurable via Django settings.
 - Removed the unsafe btree index on `Company.emails` and bounded the denormalized company email summary to prevent oversized index-row errors during HN job analysis.
 
+### Fixed
+- Sanitized Sentry/PostHog/OTel telemetry attributes and disabled PostHog integrations for blank API keys to prevent observability exporters from raising runtime errors.
+
 ## [0.0.3] - 2024-06-25
 ### Added
 - Search for titles and technologies

--- a/hn_jobs/settings/base.py
+++ b/hn_jobs/settings/base.py
@@ -91,10 +91,10 @@ CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS")
 
 DEBUG = env("DEBUG")
 
-POSTHOG_API_KEY = env("POSTHOG_API_KEY", default="")
-POSTHOG_HOST = env("POSTHOG_HOST", default="https://us.posthog.com").rstrip("/")
-POSTHOG_INGEST_HOST = env("POSTHOG_INGEST_HOST", default="https://us.i.posthog.com").rstrip("/")
-POSTHOG_ENABLED = env.bool("POSTHOG_ENABLED", default=bool(POSTHOG_API_KEY) and not DEBUG)
+POSTHOG_API_KEY = env("POSTHOG_API_KEY", default="").strip()
+POSTHOG_HOST = env("POSTHOG_HOST", default="https://us.posthog.com").strip().rstrip("/")
+POSTHOG_INGEST_HOST = env("POSTHOG_INGEST_HOST", default="https://us.i.posthog.com").strip().rstrip("/")
+POSTHOG_ENABLED = env.bool("POSTHOG_ENABLED", default=bool(POSTHOG_API_KEY) and not DEBUG) and bool(POSTHOG_API_KEY)
 POSTHOG_AI_OBSERVABILITY_ENABLED = env.bool(
     "POSTHOG_AI_OBSERVABILITY_ENABLED",
     default=POSTHOG_ENABLED,
@@ -561,7 +561,7 @@ LOGGING = {
 
 if POSTHOG_LOGS_CONFIGURED:
     LOGGING["handlers"]["posthog_logs"] = {
-        "class": "opentelemetry.sdk._logs.LoggingHandler",
+        "class": "hn_jobs.settings.observability.SanitizingOTelLoggingHandler",
         "level": POSTHOG_LOG_LEVEL,
     }
     LOGGING["loggers"]["tjalerts"]["handlers"].append("posthog_logs")

--- a/hn_jobs/settings/logging_utils.py
+++ b/hn_jobs/settings/logging_utils.py
@@ -49,17 +49,24 @@ def normalize_telemetry_attribute(value):
     if isinstance(value, BaseException):
         return f"{type(value).__name__}: {value}"
 
+    if isinstance(value, (list, tuple)):
+        return [normalize_telemetry_attribute(item) for item in value]
+
     return str(value)
 
 
+def normalize_telemetry_attributes(attributes):
+    return {key: normalize_telemetry_attribute(value) for key, value in (attributes or {}).items()}
+
+
 def enrich_sentry_log(log, _hint):
-    log.setdefault("attributes", {})
+    log["attributes"] = normalize_telemetry_attributes(log.get("attributes"))
     log["attributes"]["service.name"] = "tjalerts"
     return log
 
 
 def enrich_sentry_metric(metric, _hint):
-    metric.setdefault("attributes", {})
+    metric["attributes"] = normalize_telemetry_attributes(metric.get("attributes"))
     metric["attributes"]["service.name"] = "tjalerts"
     return metric
 

--- a/hn_jobs/settings/observability.py
+++ b/hn_jobs/settings/observability.py
@@ -59,6 +59,7 @@ def build_posthog_span_processor(*, api_key, ingest_host):
 
 
 def configure_posthog_ai_observability(*, api_key, ingest_host, environment, enabled):
+    api_key = normalize_api_key(api_key)
     if not enabled or not api_key:
         return None
 

--- a/hn_jobs/settings/observability.py
+++ b/hn_jobs/settings/observability.py
@@ -6,17 +6,32 @@ from opentelemetry import trace
 from opentelemetry._logs import get_logger_provider, set_logger_provider
 from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
 from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
-from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.resources import DEPLOYMENT_ENVIRONMENT, SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider
 from posthog.ai.otel import PostHogSpanProcessor
 
+from hn_jobs.settings.logging_utils import normalize_telemetry_attributes
+
 
 logger = logging.getLogger(__name__)
 
 
+class SanitizingOTelLoggingHandler(LoggingHandler):
+    @staticmethod
+    def _get_attributes(record):
+        return normalize_telemetry_attributes(LoggingHandler._get_attributes(record))
+
+
+def normalize_api_key(api_key):
+    return str(api_key or "").strip()
+
+
 def configure_posthog_client(*, api_key, host, enabled, debug):
+    api_key = normalize_api_key(api_key)
+    enabled = bool(enabled and api_key)
+
     posthog.project_api_key = api_key
     posthog.host = host
     posthog.disabled = not enabled
@@ -36,6 +51,7 @@ def build_posthog_resource(*, environment):
 
 
 def build_posthog_span_processor(*, api_key, ingest_host):
+    api_key = normalize_api_key(api_key)
     if not api_key:
         return None
 
@@ -63,6 +79,7 @@ def instrument_openai():
 
 
 def configure_posthog_logs(*, api_key, ingest_host, environment, enabled, timeout_seconds=10):
+    api_key = normalize_api_key(api_key)
     if not enabled or not api_key:
         return False
 

--- a/hn_jobs/tests.py
+++ b/hn_jobs/tests.py
@@ -5,7 +5,11 @@ import posthog
 from django.test import SimpleTestCase
 
 from hn_jobs.settings.logging_utils import enrich_sentry_log, enrich_sentry_metric, normalize_telemetry_attribute
-from hn_jobs.settings.observability import SanitizingOTelLoggingHandler, configure_posthog_client
+from hn_jobs.settings.observability import (
+    SanitizingOTelLoggingHandler,
+    configure_posthog_ai_observability,
+    configure_posthog_client,
+)
 from hn_jobs.sitemaps import HighestPaidJobsListicleSitemap
 
 
@@ -51,6 +55,18 @@ class ObservabilityTests(SimpleTestCase):
         finally:
             posthog.project_api_key = original_api_key
             posthog.disabled = original_disabled
+
+    def test_posthog_ai_observability_treats_whitespace_api_key_as_disabled(self):
+        with patch("hn_jobs.settings.observability.build_posthog_span_processor") as build_processor_mock:
+            result = configure_posthog_ai_observability(
+                api_key="   ",
+                ingest_host="https://us.i.posthog.com",
+                environment="test",
+                enabled=True,
+            )
+
+        assert result is None
+        build_processor_mock.assert_not_called()
 
     def test_otel_log_handler_normalizes_record_extra_attributes(self):
         record = logging.LogRecord(

--- a/hn_jobs/tests.py
+++ b/hn_jobs/tests.py
@@ -1,7 +1,11 @@
+import logging
 from unittest.mock import patch
 
+import posthog
 from django.test import SimpleTestCase
 
+from hn_jobs.settings.logging_utils import enrich_sentry_log, enrich_sentry_metric, normalize_telemetry_attribute
+from hn_jobs.settings.observability import SanitizingOTelLoggingHandler, configure_posthog_client
 from hn_jobs.sitemaps import HighestPaidJobsListicleSitemap
 
 
@@ -15,3 +19,53 @@ class SitemapTests(SimpleTestCase):
             assert HighestPaidJobsListicleSitemap().lastmod(technology) is None
 
         filter_mock.assert_called_once_with(technologies=technology)
+
+
+class ObservabilityTests(SimpleTestCase):
+    def test_normalize_telemetry_attribute_handles_exporter_unsafe_values(self):
+        error = ValueError("broken")
+
+        assert normalize_telemetry_attribute({0.02}) == "{0.02}"
+        assert normalize_telemetry_attribute(error) == "ValueError: broken"
+
+    def test_sentry_log_and_metric_attributes_are_normalized(self):
+        error = ValueError("broken")
+
+        log = enrich_sentry_log({"attributes": {"ratio": {0.02}, "error": error}}, None)
+        metric = enrich_sentry_metric({"attributes": {"ratio": {0.02}, "error": error}}, None)
+
+        assert log["attributes"]["ratio"] == "{0.02}"
+        assert log["attributes"]["error"] == "ValueError: broken"
+        assert metric["attributes"]["ratio"] == "{0.02}"
+        assert metric["attributes"]["error"] == "ValueError: broken"
+
+    def test_posthog_client_treats_whitespace_api_key_as_disabled(self):
+        original_api_key = posthog.project_api_key
+        original_disabled = posthog.disabled
+
+        try:
+            configure_posthog_client(api_key="   ", host="https://us.i.posthog.com", enabled=True, debug=False)
+
+            assert posthog.project_api_key == ""
+            assert posthog.disabled is True
+        finally:
+            posthog.project_api_key = original_api_key
+            posthog.disabled = original_disabled
+
+    def test_otel_log_handler_normalizes_record_extra_attributes(self):
+        record = logging.LogRecord(
+            name="tjalerts.test",
+            level=logging.WARNING,
+            pathname=__file__,
+            lineno=1,
+            msg="message",
+            args=(),
+            exc_info=None,
+        )
+        record.ratio = {0.02}
+        record.error = ValueError("broken")
+
+        attributes = SanitizingOTelLoggingHandler._get_attributes(record)
+
+        assert attributes["ratio"] == "{0.02}"
+        assert attributes["error"] == "ValueError: broken"

--- a/hn_jobs/tests.py
+++ b/hn_jobs/tests.py
@@ -46,6 +46,8 @@ class ObservabilityTests(SimpleTestCase):
     def test_posthog_client_treats_whitespace_api_key_as_disabled(self):
         original_api_key = posthog.project_api_key
         original_disabled = posthog.disabled
+        original_host = posthog.host
+        original_debug = posthog.debug
 
         try:
             configure_posthog_client(api_key="   ", host="https://us.i.posthog.com", enabled=True, debug=False)
@@ -55,6 +57,8 @@ class ObservabilityTests(SimpleTestCase):
         finally:
             posthog.project_api_key = original_api_key
             posthog.disabled = original_disabled
+            posthog.host = original_host
+            posthog.debug = original_debug
 
     def test_posthog_ai_observability_treats_whitespace_api_key_as_disabled(self):
         with patch("hn_jobs.settings.observability.build_posthog_span_processor") as build_processor_mock:


### PR DESCRIPTION
## Summary
- normalize Sentry/PostHog/OTel telemetry attributes before exporter encoding
- use a sanitizing OTel logging handler for PostHog log export paths
- strip PostHog API key/host settings and keep optional integrations disabled when the key is blank
- add regression coverage for set/exception attributes and whitespace PostHog keys

## Sentry issues
- https://rasulkireev.sentry.io/issues/7520591755/
- https://rasulkireev.sentry.io/issues/7520582254/
- https://rasulkireev.sentry.io/issues/7520582315/

## Tests
- PASS: targeted Django tests for `hn_jobs.tests.ObservabilityTests` and `hn_jobs.tests.SitemapTests` (6 tests)
- PASS: `python -m py_compile hn_jobs/settings/logging_utils.py hn_jobs/settings/observability.py hn_jobs/settings/base.py hn_jobs/tests.py`
- PASS: `git diff --check`
- NOTE: full `manage.py test` is blocked locally because existing migrations contain PostgreSQL-specific index SQL that SQLite rejects (`near "WITH": syntax error`).

## Review gate
- Greptile latest pass on head `13ecd1645d0c54f6d29f7cee99607f3d804dd62a`: 5/5.
- Previous actionable Greptile feedback was addressed and the review thread is resolved.
