### PR TITLE
[Observability] Send Request Telemetry to Sentry

### DIFF
--- a/hn_jobs/middleware.py
+++ b/hn_jobs/middleware.py
@@ -1,7 +1,11 @@
+import logging
 import time
 
 import sentry_sdk
 from django.conf import settings
+
+
+logger = logging.getLogger(__name__)
 
 
 def route_name_from_request(request):
@@ -12,14 +16,15 @@ def route_name_from_request(request):
     return "unknown"
 
 
-def capture_http_server_metrics(request, *, duration_ms, status_code):
-    status_class = f"{status_code // 100}xx" if status_code else "exception"
+def capture_http_server_metrics(request, *, duration_ms, status_code, error=None):
     attributes = {
         "http.request.method": request.method,
         "http.response.status_code": status_code,
-        "http.response.status_class": status_class,
+        "http.response.status_class": f"{status_code // 100}xx",
         "http.route": route_name_from_request(request),
     }
+    if error is not None:
+        attributes["error.type"] = type(error).__name__
 
     if settings.SENTRY_ENABLE_METRICS:
         try:
@@ -31,7 +36,7 @@ def capture_http_server_metrics(request, *, duration_ms, status_code):
                 attributes=attributes,
             )
         except Exception:
-            pass
+            logger.debug("Failed to emit Sentry request metrics", exc_info=True)
 
     if settings.SENTRY_ENABLE_LOGS:
         try:
@@ -46,7 +51,7 @@ def capture_http_server_metrics(request, *, duration_ms, status_code):
                 },
             )
         except Exception:
-            pass
+            logger.debug("Failed to emit Sentry request log", exc_info=True)
 
 
 class SentryMetricsMiddleware:
@@ -60,9 +65,9 @@ class SentryMetricsMiddleware:
         start_time = time.perf_counter()
         try:
             response = self.get_response(request)
-        except Exception:
+        except Exception as error:
             duration_ms = (time.perf_counter() - start_time) * 1000
-            capture_http_server_metrics(request, duration_ms=duration_ms, status_code=0)
+            capture_http_server_metrics(request, duration_ms=duration_ms, status_code=500, error=error)
             raise
 
         duration_ms = (time.perf_counter() - start_time) * 1000

--- a/hn_jobs/middleware.py
+++ b/hn_jobs/middleware.py
@@ -4,35 +4,68 @@ import sentry_sdk
 from django.conf import settings
 
 
+def route_name_from_request(request):
+    resolver_match = getattr(request, "resolver_match", None)
+    if resolver_match and resolver_match.view_name:
+        return resolver_match.view_name
+
+    return "unknown"
+
+
+def capture_http_server_metrics(request, *, duration_ms, status_code):
+    status_class = f"{status_code // 100}xx" if status_code else "exception"
+    attributes = {
+        "http.request.method": request.method,
+        "http.response.status_code": status_code,
+        "http.response.status_class": status_class,
+        "http.route": route_name_from_request(request),
+    }
+
+    if settings.SENTRY_ENABLE_METRICS:
+        try:
+            sentry_sdk.metrics.count("tjalerts.http.server.requests", 1, attributes=attributes)
+            sentry_sdk.metrics.distribution(
+                "tjalerts.http.server.duration",
+                duration_ms,
+                unit="millisecond",
+                attributes=attributes,
+            )
+        except Exception:
+            pass
+
+    if settings.SENTRY_ENABLE_LOGS:
+        try:
+            sentry_sdk.logger.info(
+                "tjalerts.http.server.request",
+                attributes={
+                    **attributes,
+                    "metric.name": "tjalerts.http.server.duration",
+                    "metric.value": duration_ms,
+                    "metric.unit": "millisecond",
+                    "service.name": "tjalerts",
+                },
+            )
+        except Exception:
+            pass
+
+
 class SentryMetricsMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
-        if not settings.SENTRY_DSN or not settings.SENTRY_ENABLE_METRICS:
+        if not settings.SENTRY_DSN or not (settings.SENTRY_ENABLE_METRICS or settings.SENTRY_ENABLE_LOGS):
             return self.get_response(request)
 
         start_time = time.perf_counter()
-        response = self.get_response(request)
+        try:
+            response = self.get_response(request)
+        except Exception:
+            duration_ms = (time.perf_counter() - start_time) * 1000
+            capture_http_server_metrics(request, duration_ms=duration_ms, status_code=0)
+            raise
+
         duration_ms = (time.perf_counter() - start_time) * 1000
-
-        route = "unknown"
-        if getattr(request, "resolver_match", None) and request.resolver_match.view_name:
-            route = request.resolver_match.view_name
-
-        attributes = {
-            "http.request.method": request.method,
-            "http.response.status_code": response.status_code,
-            "http.response.status_class": f"{response.status_code // 100}xx",
-            "http.route": route,
-        }
-
-        sentry_sdk.metrics.count("tjalerts.http.server.requests", 1, attributes=attributes)
-        sentry_sdk.metrics.distribution(
-            "tjalerts.http.server.duration",
-            duration_ms,
-            unit="millisecond",
-            attributes=attributes,
-        )
+        capture_http_server_metrics(request, duration_ms=duration_ms, status_code=response.status_code)
 
         return response

--- a/hn_jobs/settings/base.py
+++ b/hn_jobs/settings/base.py
@@ -456,7 +456,7 @@ if SENTRY_DSN:
             LoggingIntegration(
                 level=SENTRY_LOG_LEVEL,
                 event_level=None,
-                sentry_logs_level=None,
+                sentry_logs_level=SENTRY_LOG_LEVEL if SENTRY_ENABLE_LOGS else None,
             ),
         ],
         attach_stacktrace=True,

--- a/hn_jobs/settings/logging_utils.py
+++ b/hn_jobs/settings/logging_utils.py
@@ -42,6 +42,10 @@ def scrubbing_callback(m: logfire.ScrubMatch):
         return m.value
 
 
+def stable_json_sort_key(value):
+    return json.dumps(value, sort_keys=True, default=str)
+
+
 def normalize_telemetry_attribute(value):
     if value is None:
         return ""
@@ -59,13 +63,22 @@ def normalize_telemetry_attribute(value):
         return [normalize_telemetry_attribute(item) for item in value]
 
     if isinstance(value, (set, frozenset)):
-        return str(value)
+        normalized = [normalize_telemetry_attribute(item) for item in value]
+        return json.dumps(sorted(normalized, key=stable_json_sort_key), sort_keys=True, default=str)
 
     if isinstance(value, Mapping):
         normalized = {str(key): normalize_telemetry_attribute(item) for key, item in value.items()}
         return json.dumps(normalized, sort_keys=True, default=str)
 
     return str(value)
+
+
+def normalize_telemetry_body(value):
+    normalized = normalize_telemetry_attribute(value)
+    if isinstance(normalized, str):
+        return normalized
+
+    return json.dumps(normalized, sort_keys=True, default=str)
 
 
 def normalize_telemetry_attributes(attributes):

--- a/hn_jobs/settings/logging_utils.py
+++ b/hn_jobs/settings/logging_utils.py
@@ -1,4 +1,7 @@
+import json
 import logging
+from collections.abc import Mapping
+from uuid import UUID
 
 import logfire
 import sentry_sdk
@@ -46,17 +49,27 @@ def normalize_telemetry_attribute(value):
     if isinstance(value, (str, bool, int, float)):
         return value
 
+    if isinstance(value, UUID):
+        return str(value)
+
     if isinstance(value, BaseException):
         return f"{type(value).__name__}: {value}"
 
     if isinstance(value, (list, tuple)):
         return [normalize_telemetry_attribute(item) for item in value]
 
+    if isinstance(value, (set, frozenset)):
+        return str(value)
+
+    if isinstance(value, Mapping):
+        normalized = {str(key): normalize_telemetry_attribute(item) for key, item in value.items()}
+        return json.dumps(normalized, sort_keys=True, default=str)
+
     return str(value)
 
 
 def normalize_telemetry_attributes(attributes):
-    return {key: normalize_telemetry_attribute(value) for key, value in (attributes or {}).items()}
+    return {str(key): normalize_telemetry_attribute(value) for key, value in (attributes or {}).items()}
 
 
 def enrich_sentry_log(log, _hint):

--- a/hn_jobs/settings/observability.py
+++ b/hn_jobs/settings/observability.py
@@ -13,7 +13,7 @@ from opentelemetry.sdk.resources import DEPLOYMENT_ENVIRONMENT, SERVICE_NAME, Re
 from opentelemetry.sdk.trace import TracerProvider
 from posthog.ai.otel import PostHogSpanProcessor
 
-from hn_jobs.settings.logging_utils import normalize_telemetry_attribute, normalize_telemetry_attributes
+from hn_jobs.settings.logging_utils import normalize_telemetry_attributes, normalize_telemetry_body
 
 
 logger = logging.getLogger(__name__)
@@ -27,7 +27,7 @@ class SanitizingOTelLoggingHandler(LoggingHandler):
     def _translate(self, record):
         sanitized_record = copy(record)
         if not sanitized_record.args and not isinstance(sanitized_record.msg, str):
-            sanitized_record.msg = normalize_telemetry_attribute(sanitized_record.msg)
+            sanitized_record.msg = normalize_telemetry_body(sanitized_record.msg)
 
         return super()._translate(sanitized_record)
 

--- a/hn_jobs/settings/observability.py
+++ b/hn_jobs/settings/observability.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from copy import copy
 
 import posthog
 from opentelemetry import trace
@@ -12,7 +13,7 @@ from opentelemetry.sdk.resources import DEPLOYMENT_ENVIRONMENT, SERVICE_NAME, Re
 from opentelemetry.sdk.trace import TracerProvider
 from posthog.ai.otel import PostHogSpanProcessor
 
-from hn_jobs.settings.logging_utils import normalize_telemetry_attributes
+from hn_jobs.settings.logging_utils import normalize_telemetry_attribute, normalize_telemetry_attributes
 
 
 logger = logging.getLogger(__name__)
@@ -22,6 +23,13 @@ class SanitizingOTelLoggingHandler(LoggingHandler):
     @staticmethod
     def _get_attributes(record):
         return normalize_telemetry_attributes(LoggingHandler._get_attributes(record))
+
+    def _translate(self, record):
+        sanitized_record = copy(record)
+        if not sanitized_record.args and not isinstance(sanitized_record.msg, str):
+            sanitized_record.msg = normalize_telemetry_attribute(sanitized_record.msg)
+
+        return super()._translate(sanitized_record)
 
 
 def normalize_api_key(api_key):

--- a/hn_jobs/tests.py
+++ b/hn_jobs/tests.py
@@ -7,7 +7,12 @@ import posthog
 from django.test import SimpleTestCase, override_settings
 
 from hn_jobs.middleware import SentryMetricsMiddleware
-from hn_jobs.settings.logging_utils import enrich_sentry_log, enrich_sentry_metric, normalize_telemetry_attribute
+from hn_jobs.settings.logging_utils import (
+    enrich_sentry_log,
+    enrich_sentry_metric,
+    normalize_telemetry_attribute,
+    normalize_telemetry_body,
+)
 from hn_jobs.settings.observability import (
     SanitizingOTelLoggingHandler,
     configure_posthog_ai_observability,
@@ -33,9 +38,11 @@ class ObservabilityTests(SimpleTestCase):
         error = ValueError("broken")
         request_id = UUID("946539af-c999-421e-9ecb-65d47934c45c")
 
-        assert normalize_telemetry_attribute({0.02}) == "{0.02}"
+        assert normalize_telemetry_attribute({0.02}) == "[0.02]"
+        assert normalize_telemetry_attribute({"beta", "alpha"}) == '["alpha", "beta"]'
         assert normalize_telemetry_attribute(error) == "ValueError: broken"
         assert normalize_telemetry_attribute(request_id) == "946539af-c999-421e-9ecb-65d47934c45c"
+        assert normalize_telemetry_body([request_id]) == '["946539af-c999-421e-9ecb-65d47934c45c"]'
         assert (
             normalize_telemetry_attribute({"request_id": request_id})
             == '{"request_id": "946539af-c999-421e-9ecb-65d47934c45c"}'
@@ -47,9 +54,9 @@ class ObservabilityTests(SimpleTestCase):
         log = enrich_sentry_log({"attributes": {"ratio": {0.02}, "error": error}}, None)
         metric = enrich_sentry_metric({"attributes": {"ratio": {0.02}, "error": error}}, None)
 
-        assert log["attributes"]["ratio"] == "{0.02}"
+        assert log["attributes"]["ratio"] == "[0.02]"
         assert log["attributes"]["error"] == "ValueError: broken"
-        assert metric["attributes"]["ratio"] == "{0.02}"
+        assert metric["attributes"]["ratio"] == "[0.02]"
         assert metric["attributes"]["error"] == "ValueError: broken"
 
     def test_posthog_client_treats_whitespace_api_key_as_disabled(self):
@@ -96,7 +103,7 @@ class ObservabilityTests(SimpleTestCase):
 
         attributes = SanitizingOTelLoggingHandler._get_attributes(record)
 
-        assert attributes["ratio"] == "{0.02}"
+        assert attributes["ratio"] == "[0.02]"
         assert attributes["error"] == "ValueError: broken"
 
     def test_otel_log_handler_normalizes_structured_record_body(self):
@@ -113,6 +120,11 @@ class ObservabilityTests(SimpleTestCase):
         translated = SanitizingOTelLoggingHandler()._translate(record)
 
         assert translated.body == '{"request_id": "946539af-c999-421e-9ecb-65d47934c45c"}'
+
+        record.msg = [UUID("946539af-c999-421e-9ecb-65d47934c45c")]
+        translated = SanitizingOTelLoggingHandler()._translate(record)
+
+        assert translated.body == '["946539af-c999-421e-9ecb-65d47934c45c"]'
 
     @override_settings(SENTRY_DSN="https://public@example.com/1", SENTRY_ENABLE_METRICS=True, SENTRY_ENABLE_LOGS=True)
     def test_sentry_metrics_middleware_emits_metrics_and_structured_log(self):
@@ -172,4 +184,6 @@ class ObservabilityTests(SimpleTestCase):
         count_mock.assert_called_once()
         distribution_mock.assert_called_once()
         logger_mock.assert_called_once()
-        assert logger_mock.call_args.kwargs["attributes"]["http.response.status_class"] == "exception"
+        assert logger_mock.call_args.kwargs["attributes"]["error.type"] == "ValueError"
+        assert logger_mock.call_args.kwargs["attributes"]["http.response.status_code"] == 500
+        assert logger_mock.call_args.kwargs["attributes"]["http.response.status_class"] == "5xx"

--- a/hn_jobs/tests.py
+++ b/hn_jobs/tests.py
@@ -1,9 +1,12 @@
 import logging
+from types import SimpleNamespace
 from unittest.mock import patch
+from uuid import UUID
 
 import posthog
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 
+from hn_jobs.middleware import SentryMetricsMiddleware
 from hn_jobs.settings.logging_utils import enrich_sentry_log, enrich_sentry_metric, normalize_telemetry_attribute
 from hn_jobs.settings.observability import (
     SanitizingOTelLoggingHandler,
@@ -28,9 +31,15 @@ class SitemapTests(SimpleTestCase):
 class ObservabilityTests(SimpleTestCase):
     def test_normalize_telemetry_attribute_handles_exporter_unsafe_values(self):
         error = ValueError("broken")
+        request_id = UUID("946539af-c999-421e-9ecb-65d47934c45c")
 
         assert normalize_telemetry_attribute({0.02}) == "{0.02}"
         assert normalize_telemetry_attribute(error) == "ValueError: broken"
+        assert normalize_telemetry_attribute(request_id) == "946539af-c999-421e-9ecb-65d47934c45c"
+        assert (
+            normalize_telemetry_attribute({"request_id": request_id})
+            == '{"request_id": "946539af-c999-421e-9ecb-65d47934c45c"}'
+        )
 
     def test_sentry_log_and_metric_attributes_are_normalized(self):
         error = ValueError("broken")
@@ -89,3 +98,78 @@ class ObservabilityTests(SimpleTestCase):
 
         assert attributes["ratio"] == "{0.02}"
         assert attributes["error"] == "ValueError: broken"
+
+    def test_otel_log_handler_normalizes_structured_record_body(self):
+        record = logging.LogRecord(
+            name="tjalerts.test",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg={"request_id": UUID("946539af-c999-421e-9ecb-65d47934c45c")},
+            args=(),
+            exc_info=None,
+        )
+
+        translated = SanitizingOTelLoggingHandler()._translate(record)
+
+        assert translated.body == '{"request_id": "946539af-c999-421e-9ecb-65d47934c45c"}'
+
+    @override_settings(SENTRY_DSN="https://public@example.com/1", SENTRY_ENABLE_METRICS=True, SENTRY_ENABLE_LOGS=True)
+    def test_sentry_metrics_middleware_emits_metrics_and_structured_log(self):
+        request = SimpleNamespace(method="GET", resolver_match=SimpleNamespace(view_name="jobs:list"))
+        response = SimpleNamespace(status_code=200)
+        middleware = SentryMetricsMiddleware(lambda _request: response)
+
+        with (
+            patch("hn_jobs.middleware.sentry_sdk.metrics.count") as count_mock,
+            patch("hn_jobs.middleware.sentry_sdk.metrics.distribution") as distribution_mock,
+            patch("hn_jobs.middleware.sentry_sdk.logger.info") as logger_mock,
+        ):
+            result = middleware(request)
+
+        assert result is response
+        count_mock.assert_called_once()
+        distribution_mock.assert_called_once()
+        logger_mock.assert_called_once()
+        assert logger_mock.call_args.kwargs["attributes"]["http.route"] == "jobs:list"
+        assert logger_mock.call_args.kwargs["attributes"]["http.response.status_code"] == 200
+
+    @override_settings(SENTRY_DSN="https://public@example.com/1", SENTRY_ENABLE_METRICS=False, SENTRY_ENABLE_LOGS=True)
+    def test_sentry_metrics_middleware_logs_when_metrics_are_disabled(self):
+        request = SimpleNamespace(method="GET", resolver_match=SimpleNamespace(view_name="jobs:list"))
+        response = SimpleNamespace(status_code=200)
+        middleware = SentryMetricsMiddleware(lambda _request: response)
+
+        with (
+            patch("hn_jobs.middleware.sentry_sdk.metrics.count") as count_mock,
+            patch("hn_jobs.middleware.sentry_sdk.metrics.distribution") as distribution_mock,
+            patch("hn_jobs.middleware.sentry_sdk.logger.info") as logger_mock,
+        ):
+            result = middleware(request)
+
+        assert result is response
+        count_mock.assert_not_called()
+        distribution_mock.assert_not_called()
+        logger_mock.assert_called_once()
+
+    @override_settings(SENTRY_DSN="https://public@example.com/1", SENTRY_ENABLE_METRICS=True, SENTRY_ENABLE_LOGS=True)
+    def test_sentry_metrics_middleware_emits_exception_metric(self):
+        request = SimpleNamespace(method="GET", resolver_match=SimpleNamespace(view_name="jobs:list"))
+
+        def raise_error(_request):
+            raise ValueError("broken")
+
+        middleware = SentryMetricsMiddleware(raise_error)
+
+        with (
+            patch("hn_jobs.middleware.sentry_sdk.metrics.count") as count_mock,
+            patch("hn_jobs.middleware.sentry_sdk.metrics.distribution") as distribution_mock,
+            patch("hn_jobs.middleware.sentry_sdk.logger.info") as logger_mock,
+        ):
+            with self.assertRaises(ValueError):
+                middleware(request)
+
+        count_mock.assert_called_once()
+        distribution_mock.assert_called_once()
+        logger_mock.assert_called_once()
+        assert logger_mock.call_args.kwargs["attributes"]["http.response.status_class"] == "exception"


### PR DESCRIPTION
## Summary
- enable Sentry's logs ingestion path when SENTRY_ENABLE_LOGS is on
- mirror HTTP request duration/status/error telemetry into structured Sentry logs as a visibility fallback for custom metrics
- harden OpenTelemetry/Sentry serialization for UUIDs, mappings, deterministic sets, and non-string structured log bodies
- address Greptile feedback by using 500 for exception-path request telemetry and adding debug diagnostics for SDK send failures

## Tests
- python3 -m compileall hn_jobs/settings/logging_utils.py hn_jobs/settings/observability.py hn_jobs/settings/base.py hn_jobs/middleware.py hn_jobs/tests.py
- git diff --check
- poetry run python manage.py test hn_jobs.tests.ObservabilityTests --verbosity=2 (with local Python 3.14 pkgutil.find_loader compatibility shim)
- poetry run python manage.py check (with local Python 3.14 pkgutil.find_loader compatibility shim)

## Review status
- PR is ready for review, clean, and mergeable
- No PR CI workflow is configured; repo workflows are main-branch deploy workflows only
- Greptile review threads are resolved
