### PR TITLE
Fix UUID telemetry attribute export

### DIFF
--- a/hn_jobs/settings/base.py
+++ b/hn_jobs/settings/base.py
@@ -35,6 +35,7 @@ from structlog_sentry import SentryProcessor
 from hn_jobs.settings.logging_utils import (
     enrich_sentry_log,
     enrich_sentry_metric,
+    normalize_structlog_event,
     scrubbing_callback,
     send_structlog_to_sentry,
 )
@@ -576,6 +577,7 @@ structlog_processors = [
     structlog.stdlib.PositionalArgumentsFormatter(),
     structlog.processors.StackInfoRenderer(),
     # structlog.processors.format_exc_info,
+    normalize_structlog_event,
 ]
 
 if SENTRY_DSN and SENTRY_ENABLE_LOGS:

--- a/hn_jobs/settings/logging_utils.py
+++ b/hn_jobs/settings/logging_utils.py
@@ -6,15 +6,26 @@ from uuid import UUID
 import logfire
 import sentry_sdk
 
-SENTRY_LOG_METHODS = {
-    "debug": sentry_sdk.logger.debug,
-    "info": sentry_sdk.logger.info,
-    "warning": sentry_sdk.logger.warning,
-    "warn": sentry_sdk.logger.warning,
-    "error": sentry_sdk.logger.error,
-    "critical": sentry_sdk.logger.fatal,
-    "fatal": sentry_sdk.logger.fatal,
+
+SENTRY_LOG_METHOD_NAMES = {
+    "debug": "debug",
+    "info": "info",
+    "warning": "warning",
+    "warn": "warning",
+    "error": "error",
+    "critical": "fatal",
+    "fatal": "fatal",
 }
+
+
+def get_sentry_log_method(level):
+    logger = getattr(sentry_sdk, "logger", None)
+    if logger is None:
+        return None
+
+    method_name = SENTRY_LOG_METHOD_NAMES.get(level, "info")
+    return getattr(logger, method_name, None)
+
 
 SENTRY_LOG_LEVELS = {
     "debug": logging.DEBUG,
@@ -85,6 +96,13 @@ def normalize_telemetry_attributes(attributes):
     return {str(key): normalize_telemetry_attribute(value) for key, value in (attributes or {}).items()}
 
 
+def normalize_structlog_event(_logger, _method_name, event_dict):
+    return {
+        key: value if key in SENTRY_STRUCTLOG_RESERVED_KEYS else normalize_telemetry_attribute(value)
+        for key, value in event_dict.items()
+    }
+
+
 def enrich_sentry_log(log, _hint):
     log["attributes"] = normalize_telemetry_attributes(log.get("attributes"))
     log["attributes"]["service.name"] = "tjalerts"
@@ -103,7 +121,10 @@ def send_structlog_to_sentry(_logger, _method_name, event_dict, *, min_level=log
         if SENTRY_LOG_LEVELS.get(level, logging.INFO) < min_level:
             return event_dict
 
-        log_method = SENTRY_LOG_METHODS.get(level, sentry_sdk.logger.info)
+        log_method = get_sentry_log_method(level)
+        if log_method is None:
+            return event_dict
+
         message = str(event_dict.get("event", ""))
 
         attributes = {

--- a/hn_jobs/tests.py
+++ b/hn_jobs/tests.py
@@ -10,6 +10,8 @@ from hn_jobs.middleware import SentryMetricsMiddleware
 from hn_jobs.settings.logging_utils import (
     enrich_sentry_log,
     enrich_sentry_metric,
+    get_sentry_log_method,
+    normalize_structlog_event,
     normalize_telemetry_attribute,
     normalize_telemetry_body,
 )
@@ -48,16 +50,44 @@ class ObservabilityTests(SimpleTestCase):
             == '{"request_id": "946539af-c999-421e-9ecb-65d47934c45c"}'
         )
 
+    def test_structlog_events_are_normalized_before_otel_processors(self):
+        request_id = UUID("946539af-c999-421e-9ecb-65d47934c45c")
+        record = logging.LogRecord(
+            name="tjalerts.test",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="message",
+            args=(),
+            exc_info=None,
+        )
+
+        event = normalize_structlog_event(
+            None,
+            "info",
+            {"event": "loaded", "level": "info", "tech_id": request_id, "_record": record},
+        )
+
+        assert event["tech_id"] == "946539af-c999-421e-9ecb-65d47934c45c"
+        assert event["_record"] is record
+
+    def test_sentry_log_method_returns_none_when_logs_api_is_unavailable(self):
+        with patch("hn_jobs.settings.logging_utils.sentry_sdk.logger", None, create=True):
+            assert get_sentry_log_method("info") is None
+
     def test_sentry_log_and_metric_attributes_are_normalized(self):
         error = ValueError("broken")
+        request_id = UUID("946539af-c999-421e-9ecb-65d47934c45c")
 
-        log = enrich_sentry_log({"attributes": {"ratio": {0.02}, "error": error}}, None)
-        metric = enrich_sentry_metric({"attributes": {"ratio": {0.02}, "error": error}}, None)
+        log = enrich_sentry_log({"attributes": {"ratio": {0.02}, "error": error, "item_id": request_id}}, None)
+        metric = enrich_sentry_metric({"attributes": {"ratio": {0.02}, "error": error, "item_id": request_id}}, None)
 
         assert log["attributes"]["ratio"] == "[0.02]"
         assert log["attributes"]["error"] == "ValueError: broken"
+        assert log["attributes"]["item_id"] == "946539af-c999-421e-9ecb-65d47934c45c"
         assert metric["attributes"]["ratio"] == "[0.02]"
         assert metric["attributes"]["error"] == "ValueError: broken"
+        assert metric["attributes"]["item_id"] == "946539af-c999-421e-9ecb-65d47934c45c"
 
     def test_posthog_client_treats_whitespace_api_key_as_disabled(self):
         original_api_key = posthog.project_api_key
@@ -98,13 +128,16 @@ class ObservabilityTests(SimpleTestCase):
             args=(),
             exc_info=None,
         )
+        request_id = UUID("946539af-c999-421e-9ecb-65d47934c45c")
         record.ratio = {0.02}
         record.error = ValueError("broken")
+        record.item_id = request_id
 
         attributes = SanitizingOTelLoggingHandler._get_attributes(record)
 
         assert attributes["ratio"] == "[0.02]"
         assert attributes["error"] == "ValueError: broken"
+        assert attributes["item_id"] == "946539af-c999-421e-9ecb-65d47934c45c"
 
     def test_otel_log_handler_normalizes_structured_record_body(self):
         record = logging.LogRecord(


### PR DESCRIPTION
## Summary
- Normalize structlog event attributes before telemetry processors receive them
- Convert UUIDs and nested non-OTEL-safe values into exporter-safe values
- Add regression coverage for UUID-bearing observability attributes
- Avoid import-time failure when `sentry_sdk.logger` is unavailable in local test environments

## Sentry
- Fixes Sentry issue HNJOBS-DJY: https://rasulkireev.sentry.io/issues/7520582315/
- Error: OpenTelemetry log export failed on raw `uuid.UUID` `tech_id`

## Tests
- `uv run --with structlog --with logfire --with sentry-sdk python - <<'PY' ...` smoke test for UUID structlog normalization
- `git diff --check`

Note: Full Django test execution is blocked locally because this environment lacks Docker and source-building `psycopg2` requires `pg_config`; the focused smoke covers the changed normalization path.
