### PR TITLE
[Jobs] Schedule Remote OK Imports

### DIFF
--- a/hn_jobs/settings/base.py
+++ b/hn_jobs/settings/base.py
@@ -385,7 +385,6 @@ Q_CLUSTER = {
     "retry": 4800,  # 80 minutes
     "workers": 4,
     "max_attempts": 2,
-    "catch_up": False,  # Avoid replaying every missed periodic import after worker downtime.
     "redis": env("REDIS_URL"),
     "error_reporter": {},
 }

--- a/hn_jobs/settings/base.py
+++ b/hn_jobs/settings/base.py
@@ -385,6 +385,7 @@ Q_CLUSTER = {
     "retry": 4800,  # 80 minutes
     "workers": 4,
     "max_attempts": 2,
+    "catch_up": False,  # Avoid replaying every missed periodic import after worker downtime.
     "redis": env("REDIS_URL"),
     "error_reporter": {},
 }

--- a/jobs/migrations/0035_schedule_remote_ok_import.py
+++ b/jobs/migrations/0035_schedule_remote_ok_import.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django.db import migrations
 from django.utils import timezone
 
@@ -16,7 +18,7 @@ def create_remote_ok_import_schedule(apps, schema_editor):
             "hook": "jobs.hooks.print_result",
             "schedule_type": "H",
             "repeats": -1,
-            "next_run": timezone.now(),
+            "next_run": timezone.now() + timedelta(hours=1),
         },
     )
 

--- a/jobs/migrations/0035_schedule_remote_ok_import.py
+++ b/jobs/migrations/0035_schedule_remote_ok_import.py
@@ -1,0 +1,39 @@
+from django.db import migrations
+from django.utils import timezone
+
+
+SCHEDULE_NAME = "import-remote-ok-jobs"
+SCHEDULE_FUNC = "jobs.tasks.import_remote_ok_jobs"
+
+
+def create_remote_ok_import_schedule(apps, schema_editor):
+    Schedule = apps.get_model("django_q", "Schedule")
+
+    Schedule.objects.get_or_create(
+        name=SCHEDULE_NAME,
+        defaults={
+            "func": SCHEDULE_FUNC,
+            "hook": "jobs.hooks.print_result",
+            "schedule_type": "H",
+            "repeats": -1,
+            "next_run": timezone.now(),
+        },
+    )
+
+
+def delete_remote_ok_import_schedule(apps, schema_editor):
+    Schedule = apps.get_model("django_q", "Schedule")
+
+    Schedule.objects.filter(name=SCHEDULE_NAME, func=SCHEDULE_FUNC).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("django_q", "0018_task_success_index"),
+        ("jobs", "0034_add_generic_post_source_identity"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_remote_ok_import_schedule, delete_remote_ok_import_schedule),
+    ]


### PR DESCRIPTION
## Summary
- Seed a Django Q2 hourly schedule for the verified Remote OK importer
- Defer the first scheduled run by one hour so deploy/migration does not immediately hit the Remote OK API
- Keep the schedule idempotent and reversible with a stable schedule name

## Tests
- python -m py_compile hn_jobs/settings/base.py jobs/migrations/0035_schedule_remote_ok_import.py
- docker build -f deployment/Dockerfile.python -t tjalerts-periodic-check .
- docker run ... python manage.py check
- docker run ... python manage.py makemigrations --check --dry-run
- docker run ... python manage.py migrate --plan

Note: Docker Django checks report the existing staticfiles warning for missing /app/frontend/build in the lightweight Python image.

## Review
- Greptile confidence: 5/5
- Greptile threads: 2 addressed and resolved