### PR TITLE
[Jobs] Add Employer Dedupe Filter

### DIFF
--- a/jobs/filters.py
+++ b/jobs/filters.py
@@ -2,6 +2,8 @@ import time
 
 from django import forms
 from django.core.validators import EMPTY_VALUES
+from django.db.models import F, Window
+from django.db.models.functions import RowNumber
 from django_filters import BooleanFilter, CharFilter, Filter, FilterSet, ModelMultipleChoiceFilter, OrderingFilter
 from pgvector.django import L2Distance
 
@@ -36,6 +38,16 @@ class EmptyStringFilter(BooleanFilter):
 class PostFilter(FilterSet):
     vector = VectorEmbeddingFilter(field_name="vector")
     locations = CharFilter(lookup_expr="icontains")
+    remove_duplicate_employers = BooleanFilter(
+        label="Employers",
+        method="noop_filter",
+        widget=forms.Select(
+            choices=(
+                ("", "Show all"),
+                ("true", "Remove duplicates"),
+            )
+        ),
+    )
     technologies = ModelMultipleChoiceFilter(
         queryset=lambda request: get_most_popular_technologies(),
         widget=forms.CheckboxSelectMultiple(),
@@ -84,6 +96,39 @@ class PostFilter(FilterSet):
 
         return queryset
 
+    def noop_filter(self, queryset, name, value):
+        return queryset
+
+    def remove_duplicate_employers_from_queryset(self, queryset):
+        return queryset.annotate(
+            employer_row_number=Window(
+                expression=RowNumber(),
+                partition_by=[F("company_id")],
+                order_by=self.get_employer_dedupe_ordering(queryset),
+            )
+        ).filter(employer_row_number=1)
+
+    def get_employer_dedupe_ordering(self, queryset):
+        ordering = queryset.query.order_by or queryset.model._meta.ordering or ("-submitted_datetime",)
+        order_expressions = []
+
+        for field_name in ordering:
+            if hasattr(field_name, "resolve_expression"):
+                order_expressions.append(field_name)
+                continue
+
+            if field_name == "?":
+                continue
+
+            descending = field_name.startswith("-")
+            field_name = field_name[1:] if descending else field_name
+            order_expression = F(field_name).desc(nulls_last=True) if descending else F(field_name).asc(nulls_last=True)
+            order_expressions.append(order_expression)
+
+        order_expressions.append(F("id").asc())
+
+        return order_expressions
+
     class Meta:
         model = Post
         fields = [
@@ -95,7 +140,12 @@ class PostFilter(FilterSet):
 
     @property
     def qs(self):
-        return super().qs.exclude(description__exact="")
+        queryset = super().qs.exclude(description__exact="")
+
+        if self.form.is_valid() and self.form.cleaned_data.get("remove_duplicate_employers"):
+            return self.remove_duplicate_employers_from_queryset(queryset)
+
+        return queryset
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/jobs/filters.py
+++ b/jobs/filters.py
@@ -4,7 +4,15 @@ from django import forms
 from django.core.validators import EMPTY_VALUES
 from django.db.models import F, Window
 from django.db.models.functions import RowNumber
-from django_filters import BooleanFilter, CharFilter, Filter, FilterSet, ModelMultipleChoiceFilter, OrderingFilter
+from django_filters import (
+    BooleanFilter,
+    CharFilter,
+    ChoiceFilter,
+    Filter,
+    FilterSet,
+    ModelMultipleChoiceFilter,
+    OrderingFilter,
+)
 from pgvector.django import L2Distance
 
 from hn_jobs.utils import get_tjalerts_logger
@@ -35,17 +43,26 @@ class EmptyStringFilter(BooleanFilter):
         return method(**{self.field_name: ""})
 
 
+class PostOrderingFilter(OrderingFilter):
+    def get_ordering_value(self, param):
+        if param == "-max_salary":
+            return F("max_salary").desc(nulls_last=True)
+
+        if param == "max_salary":
+            return F("max_salary").asc(nulls_last=True)
+
+        return super().get_ordering_value(param)
+
+
 class PostFilter(FilterSet):
     vector = VectorEmbeddingFilter(field_name="vector")
     locations = CharFilter(lookup_expr="icontains")
-    remove_duplicate_employers = BooleanFilter(
+    remove_duplicate_employers = ChoiceFilter(
         label="Employers",
         method="noop_filter",
-        widget=forms.Select(
-            choices=(
-                ("", "Show all"),
-                ("true", "Remove duplicates"),
-            )
+        choices=(
+            ("", "Show all"),
+            ("true", "Remove duplicates"),
         ),
     )
     technologies = ModelMultipleChoiceFilter(
@@ -60,7 +77,7 @@ class PostFilter(FilterSet):
     compensation_summary__isempty = EmptyStringFilter(field_name="compensation_summary")
     emails__isempty = EmptyStringFilter(field_name="emails")
 
-    o = OrderingFilter(
+    o = PostOrderingFilter(
         choices=(
             ("-submitted_datetime", "Date"),
             ("-max_salary", "Max Salary"),
@@ -122,9 +139,10 @@ class PostFilter(FilterSet):
 
             descending = field_name.startswith("-")
             field_name = field_name[1:] if descending else field_name
-            order_expression = F(field_name).desc(nulls_last=True) if descending else F(field_name).asc(nulls_last=True)
+            order_expression = F(field_name).desc() if descending else F(field_name).asc()
             order_expressions.append(order_expression)
 
+        order_expressions.append(F("submitted_datetime").desc())
         order_expressions.append(F("id").asc())
 
         return order_expressions
@@ -142,7 +160,7 @@ class PostFilter(FilterSet):
     def qs(self):
         queryset = super().qs.exclude(description__exact="")
 
-        if self.form.is_valid() and self.form.cleaned_data.get("remove_duplicate_employers"):
+        if self.form.is_valid() and self.form.cleaned_data.get("remove_duplicate_employers") == "true":
             return self.remove_duplicate_employers_from_queryset(queryset)
 
         return queryset
@@ -151,7 +169,7 @@ class PostFilter(FilterSet):
         super().__init__(*args, **kwargs)
 
         if self.data.get("vector"):
-            self.filters["o"] = OrderingFilter(
+            self.filters["o"] = PostOrderingFilter(
                 choices=(
                     ("-submitted_datetime", "Date"),
                     ("-max_salary", "Max Salary"),

--- a/jobs/tests.py
+++ b/jobs/tests.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from unittest.mock import Mock, patch
 
 import httpx
@@ -17,6 +18,7 @@ from jobs.enrichment import (
     extract_structured_page_context,
     read_url_with_jina,
 )
+from jobs.filters import PostFilter
 from jobs.models import Alert, Company, Post, Technology, Title
 from jobs.queries import get_most_popular_technologies, get_most_popular_titles
 from jobs.tasks import (
@@ -237,6 +239,68 @@ class CompanyEmailMergeTests(SimpleTestCase):
         long_email_blob = "a" * (MAX_COMPANY_EMAILS_LENGTH + 100)
 
         assert len(merge_company_emails("", long_email_blob)) == MAX_COMPANY_EMAILS_LENGTH
+
+
+class PostFilterTests(TestCase):
+    def test_remove_duplicate_employers_keeps_latest_post_per_employer(self):
+        now = timezone.now()
+        acme = Company.objects.create(name="Acme")
+        beta = Company.objects.create(name="Beta")
+        stale_acme_post = Post.objects.create(
+            submitted_datetime=now - timedelta(days=2),
+            company=acme,
+            description="Older Acme role",
+        )
+        latest_acme_post = Post.objects.create(
+            submitted_datetime=now,
+            company=acme,
+            description="Latest Acme role",
+        )
+        beta_post = Post.objects.create(
+            submitted_datetime=now - timedelta(hours=1),
+            company=beta,
+            description="Beta role",
+        )
+
+        filtered_posts = PostFilter(
+            {"remove_duplicate_employers": "true"},
+            queryset=Post.objects.all(),
+        ).qs
+
+        post_ids = list(filtered_posts.values_list("id", flat=True))
+
+        assert post_ids == [latest_acme_post.id, beta_post.id]
+        assert stale_acme_post.id not in post_ids
+
+    def test_remove_duplicate_employers_respects_selected_ordering(self):
+        now = timezone.now()
+        acme = Company.objects.create(name="Acme")
+        beta = Company.objects.create(name="Beta")
+        high_salary_acme_post = Post.objects.create(
+            submitted_datetime=now - timedelta(days=2),
+            company=acme,
+            description="Higher salary Acme role",
+            max_salary=200000,
+        )
+        Post.objects.create(
+            submitted_datetime=now,
+            company=acme,
+            description="Newer lower salary Acme role",
+            max_salary=100000,
+        )
+        beta_post = Post.objects.create(
+            submitted_datetime=now - timedelta(days=1),
+            company=beta,
+            description="Beta role",
+            max_salary=150000,
+        )
+
+        filtered_posts = PostFilter(
+            {"remove_duplicate_employers": "true", "o": "-max_salary"},
+            queryset=Post.objects.all(),
+        ).qs
+
+        assert list(filtered_posts.values_list("id", flat=True)) == [high_salary_acme_post.id, beta_post.id]
 
 
 class RemoteOkParsingTests(SimpleTestCase):

--- a/jobs/tests.py
+++ b/jobs/tests.py
@@ -246,7 +246,7 @@ class PostFilterTests(TestCase):
         now = timezone.now()
         acme = Company.objects.create(name="Acme")
         beta = Company.objects.create(name="Beta")
-        stale_acme_post = Post.objects.create(
+        Post.objects.create(
             submitted_datetime=now - timedelta(days=2),
             company=acme,
             description="Older Acme role",
@@ -263,16 +263,15 @@ class PostFilterTests(TestCase):
         )
 
         filtered_posts = PostFilter(
-            {"remove_duplicate_employers": "true"},
-            queryset=Post.objects.all(),
+            {"remove_duplicate_employers": "true", "o": "-submitted_datetime"},
+            queryset=Post.objects.order_by("-submitted_datetime"),
         ).qs
 
         post_ids = list(filtered_posts.values_list("id", flat=True))
 
         assert post_ids == [latest_acme_post.id, beta_post.id]
-        assert stale_acme_post.id not in post_ids
 
-    def test_remove_duplicate_employers_respects_selected_ordering(self):
+    def test_remove_duplicate_employers_respects_selected_salary_ordering(self):
         now = timezone.now()
         acme = Company.objects.create(name="Acme")
         beta = Company.objects.create(name="Beta")
@@ -281,6 +280,11 @@ class PostFilterTests(TestCase):
             company=acme,
             description="Higher salary Acme role",
             max_salary=200000,
+        )
+        Post.objects.create(
+            submitted_datetime=now - timedelta(days=1),
+            company=acme,
+            description="Acme role without salary",
         )
         Post.objects.create(
             submitted_datetime=now,
@@ -301,6 +305,40 @@ class PostFilterTests(TestCase):
         ).qs
 
         assert list(filtered_posts.values_list("id", flat=True)) == [high_salary_acme_post.id, beta_post.id]
+
+    def test_remove_duplicate_employers_supports_technology_filter(self):
+        now = timezone.now()
+        python = Technology.objects.create(name="Python")
+        acme = Company.objects.create(name="Acme")
+        beta = Company.objects.create(name="Beta")
+        stale_acme_post = Post.objects.create(
+            submitted_datetime=now - timedelta(days=2),
+            company=acme,
+            description="Older Acme Python role",
+        )
+        latest_acme_post = Post.objects.create(
+            submitted_datetime=now,
+            company=acme,
+            description="Latest Acme Python role",
+        )
+        beta_post = Post.objects.create(
+            submitted_datetime=now - timedelta(hours=1),
+            company=beta,
+            description="Beta Python role",
+        )
+        for post in (stale_acme_post, latest_acme_post, beta_post):
+            post.technologies.add(python)
+
+        filtered_posts = PostFilter(
+            {
+                "remove_duplicate_employers": "true",
+                "o": "-submitted_datetime",
+                "technologies": [str(python.id)],
+            },
+            queryset=Post.objects.order_by("-submitted_datetime"),
+        ).qs
+
+        assert list(filtered_posts.values_list("id", flat=True)) == [latest_acme_post.id, beta_post.id]
 
 
 class RemoteOkParsingTests(SimpleTestCase):

--- a/templates/jobs/all_jobs.html
+++ b/templates/jobs/all_jobs.html
@@ -76,6 +76,10 @@
             {% render_field filter.form.emails__isempty id="emails__isempty" name="emails__isempty" class="app-select mt-1" %}
           </div>
           <div>
+            <label for="remove_duplicate_employers" class="app-label">Employers</label>
+            {% render_field filter.form.remove_duplicate_employers id="remove_duplicate_employers" name="remove_duplicate_employers" class="app-select mt-1" %}
+          </div>
+          <div>
             <label for="is_remote" class="app-label">Remote</label>
             {% render_field filter.form.is_remote id="is_remote" name="is_remote" class="app-select mt-1" %}
           </div>


### PR DESCRIPTION
## Summary
- Add an Employers filter option that removes duplicate companies from job results
- Keep one post per employer after other filters run, using the active sort order for selection
- Align max-salary sorting so missing salaries are consistently ordered last in both display and dedupe logic
- Add focused coverage for date ordering, salary ordering with missing salary data, and technology+dedupe filtering

## Tests
- docker compose -p tjalerts_5d6e_pr_fix -f docker-compose.yml -f docker-compose.test.yml run --rm --no-deps backend python manage.py test jobs.tests.PostFilterTests
- git diff --check
- pre-commit hooks during commits: black, ruff, djLint, whitespace/end-of-file checks

## Review
- Greptile Confidence Score: 5/5
- All Greptile review threads resolved