### PR TITLE
[Jobs] Improve Filtering UX

### DIFF
--- a/frontend/src/controllers/search_and_select_controller.js
+++ b/frontend/src/controllers/search_and_select_controller.js
@@ -21,7 +21,9 @@ export default class extends Controller {
       preselectedIds.forEach(async (id) => {
         const response = await fetch(`${this.detailUrlValue}/${id}`);
         const details = await response.json();
-        this.addItemToSelection(details.id, details.name, details.post_count);
+        if (details && details.id) {
+          this.addItemToSelection(details.id, details.name, details.post_count);
+        }
       });
     }
   }
@@ -42,7 +44,8 @@ export default class extends Controller {
       this.searchResultsTarget.classList.add('border', 'border-zinc-200');
       this.searchResultsTarget.replaceChildren(...filteredItems.map(item => this.renderSearchResult(item)));
     } else {
-      this.clearSearchResults();
+      this.searchResultsTarget.classList.add('border', 'border-zinc-200');
+      this.searchResultsTarget.replaceChildren(this.renderEmptyResult());
     }
   }
 
@@ -68,7 +71,7 @@ export default class extends Controller {
   }
 
   removeItem(event) {
-    const itemElement = event.currentTarget.closest('div');
+    const itemElement = event.currentTarget.closest('[data-id]');
     const id = itemElement.dataset.id;
     this.selectedItems.delete(id);
     itemElement.remove();
@@ -80,20 +83,38 @@ export default class extends Controller {
   }
 
   renderSearchResult(item) {
-    const result = document.createElement('div');
-    result.className = 'cursor-pointer rounded-md p-2 text-sm text-zinc-800 hover:bg-zinc-100';
+    const result = document.createElement('button');
+    result.type = 'button';
+    result.className = 'flex w-full items-center justify-between gap-3 rounded-md p-2 text-left text-sm text-zinc-800 hover:bg-zinc-100';
     result.setAttribute('data-action', 'click->search-and-select#addItem');
     result.dataset.id = String(item.id);
     result.dataset.name = item.name;
     result.dataset.postCount = item.post_count || '';
-    result.textContent = this.formatLabel(item.name, item.post_count);
+
+    const name = document.createElement('span');
+    name.className = 'min-w-0 truncate font-medium';
+    name.textContent = item.name;
+
+    const count = document.createElement('span');
+    count.className = 'tabular shrink-0 text-xs text-zinc-500';
+    count.textContent = item.post_count ? `${item.post_count} posts` : '';
+
+    result.append(name, count);
+
+    return result;
+  }
+
+  renderEmptyResult() {
+    const result = document.createElement('div');
+    result.className = 'p-2 text-sm text-zinc-500';
+    result.textContent = 'No matches';
 
     return result;
   }
 
   renderSelectedItem(id, name, postCount) {
     const item = document.createElement('div');
-    item.className = 'tag';
+    item.className = 'tag my-0 mr-0';
     item.dataset.id = id;
 
     const label = document.createElement('span');
@@ -101,25 +122,16 @@ export default class extends Controller {
 
     const button = document.createElement('button');
     button.type = 'button';
-    button.className = 'ml-2 rounded-sm text-emerald-900 hover:bg-emerald-100';
+    button.className = 'ml-1 rounded-sm px-1 text-emerald-900 hover:bg-emerald-100';
     button.setAttribute('data-action', 'click->search-and-select#removeItem');
 
     const screenReaderLabel = document.createElement('span');
     screenReaderLabel.className = 'sr-only';
     screenReaderLabel.textContent = `Remove ${name}`;
 
-    const icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-    icon.setAttribute('class', 'h-3.5 w-3.5');
-    icon.setAttribute('fill', 'none');
-    icon.setAttribute('viewBox', '0 0 24 24');
-    icon.setAttribute('stroke', 'currentColor');
-    icon.setAttribute('aria-hidden', 'true');
-
-    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-    path.setAttribute('stroke-linecap', 'round');
-    path.setAttribute('stroke-linejoin', 'round');
-    path.setAttribute('stroke-width', '2');
-    path.setAttribute('d', 'M6 18 18 6M6 6l12 12');
+    const visualLabel = document.createElement('span');
+    visualLabel.setAttribute('aria-hidden', 'true');
+    visualLabel.textContent = 'x';
 
     const input = document.createElement('input');
     input.type = 'checkbox';
@@ -128,8 +140,7 @@ export default class extends Controller {
     input.className = 'hidden';
     input.checked = true;
 
-    icon.appendChild(path);
-    button.append(screenReaderLabel, icon);
+    button.append(screenReaderLabel, visualLabel);
     item.append(label, button, input);
 
     return item;

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -65,6 +65,54 @@
     @apply rounded-lg border border-zinc-200 bg-zinc-100/70 p-4 sm:p-6;
   }
 
+  .filter-panel {
+    @apply space-y-5 rounded-lg border border-zinc-200 bg-white p-4 sm:p-5;
+  }
+
+  .filter-section {
+    @apply border-t border-zinc-200 pt-5;
+  }
+
+  .filter-count {
+    @apply whitespace-nowrap rounded-md border border-emerald-200 bg-emerald-50 px-2 py-1 text-xs font-semibold text-emerald-800;
+  }
+
+  .filter-choice {
+    @apply flex min-h-[2.5rem] cursor-pointer items-center rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm font-medium leading-5 text-zinc-700 transition-colors duration-150 hover:border-zinc-300 hover:bg-zinc-50;
+  }
+
+  .filter-choice input {
+    @apply sr-only;
+  }
+
+  .filter-choice:has(input:checked) {
+    @apply border-emerald-300 bg-emerald-50 text-emerald-950 ring-1 ring-emerald-200;
+  }
+
+  .filter-choice:focus-within {
+    @apply outline outline-2 outline-offset-2 outline-emerald-700;
+  }
+
+  .selected-filter-list {
+    @apply mt-2 flex flex-wrap gap-1.5;
+  }
+
+  .filter-search-results {
+    @apply mt-2 max-h-64 overflow-auto rounded-md bg-white;
+  }
+
+  .result-toolbar {
+    @apply flex flex-col gap-3 rounded-lg border border-zinc-200 bg-white p-4 sm:flex-row sm:items-center sm:justify-between;
+  }
+
+  .active-filter-list {
+    @apply flex flex-wrap gap-2;
+  }
+
+  .active-filter-chip {
+    @apply inline-flex max-w-full items-center gap-2 rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-xs font-semibold text-zinc-800 hover:border-zinc-300 hover:bg-zinc-50 active:translate-y-px;
+  }
+
   .app-page-header {
     @apply border-b border-zinc-200 bg-white;
   }

--- a/jobs/filters.py
+++ b/jobs/filters.py
@@ -1,9 +1,11 @@
 import time
+from datetime import timedelta
 
 from django import forms
 from django.core.validators import EMPTY_VALUES
-from django.db.models import F, Window
+from django.db.models import F, Q, Window
 from django.db.models.functions import RowNumber
+from django.utils import timezone
 from django_filters import (
     BooleanFilter,
     CharFilter,
@@ -11,12 +13,14 @@ from django_filters import (
     Filter,
     FilterSet,
     ModelMultipleChoiceFilter,
+    NumberFilter,
     OrderingFilter,
 )
 from pgvector.django import L2Distance
 
 from hn_jobs.utils import get_tjalerts_logger
 
+from .choices import PostSource
 from .models import Post, TechnologyMapping
 from .queries import get_most_popular_technologies, get_most_popular_titles
 from .utils import get_embedding
@@ -29,7 +33,11 @@ class VectorEmbeddingFilter(Filter):
         if not value:
             return qs
 
-        return qs.annotate(distance=L2Distance("vector", get_embedding(value))).filter(distance__lt=1.25)
+        return (
+            qs.annotate(distance=L2Distance("vector", get_embedding(value)))
+            .filter(distance__lt=1.25)
+            .order_by("distance")
+        )
 
 
 class EmptyStringFilter(BooleanFilter):
@@ -54,7 +62,30 @@ class PostOrderingFilter(OrderingFilter):
         return super().get_ordering_value(param)
 
 
+HAS_FIELD_CHOICES = (
+    ("yes", "Yes"),
+    ("no", "No"),
+)
+
+MAX_KEYWORD_SEARCH_TERMS = 5
+
+POSTED_WITHIN_CHOICES = (
+    ("7", "Last 7 days"),
+    ("30", "Last 30 days"),
+    ("60", "Last 60 days"),
+)
+
+WORK_MODE_CHOICES = (
+    ("remote", "Remote roles"),
+    ("remote_only", "Remote only"),
+    ("onsite", "Onsite or hybrid"),
+    ("onsite_only", "Onsite only"),
+    ("hybrid", "Hybrid"),
+)
+
+
 class PostFilter(FilterSet):
+    q = CharFilter(method="filter_keyword_search")
     vector = VectorEmbeddingFilter(field_name="vector")
     locations = CharFilter(lookup_expr="icontains")
     remove_duplicate_employers = ChoiceFilter(
@@ -76,13 +107,90 @@ class PostFilter(FilterSet):
     )
     compensation_summary__isempty = EmptyStringFilter(field_name="compensation_summary")
     emails__isempty = EmptyStringFilter(field_name="emails")
+    has_compensation = ChoiceFilter(choices=HAS_FIELD_CHOICES, method="filter_has_compensation")
+    has_contact = ChoiceFilter(choices=HAS_FIELD_CHOICES, method="filter_has_contact")
+    posted_within = ChoiceFilter(choices=POSTED_WITHIN_CHOICES, method="filter_posted_within")
+    salary_floor = NumberFilter(method="filter_salary_floor")
+    source = ChoiceFilter(choices=PostSource.choices)
+    work_mode = ChoiceFilter(choices=WORK_MODE_CHOICES, method="filter_work_mode")
 
     o = PostOrderingFilter(
         choices=(
-            ("-submitted_datetime", "Date"),
-            ("-max_salary", "Max Salary"),
+            ("-submitted_datetime", "Newest first"),
+            ("-max_salary", "Highest salary"),
+            ("company__name", "Company A-Z"),
         )
     )
+
+    def filter_keyword_search(self, queryset, name, value):
+        if not value:
+            return queryset
+
+        search_terms = [term.strip() for term in value.split() if term.strip()][:MAX_KEYWORD_SEARCH_TERMS]
+
+        for term in search_terms:
+            queryset = queryset.filter(
+                Q(company__name__icontains=term)
+                | Q(description__icontains=term)
+                | Q(titles__name__icontains=term)
+                | Q(technologies__name__icontains=term)
+                | Q(locations__icontains=term)
+                | Q(cities__icontains=term)
+                | Q(countries__icontains=term)
+                | Q(remote_timezones__icontains=term)
+                | Q(compensation_summary__icontains=term)
+            )
+
+        return queryset.distinct()
+
+    def filter_has_compensation(self, queryset, name, value):
+        missing_compensation = Q(compensation_summary__isnull=True) | Q(compensation_summary__exact="")
+
+        if value == "yes":
+            return queryset.exclude(missing_compensation)
+        if value == "no":
+            return queryset.filter(missing_compensation)
+
+        return queryset
+
+    def filter_has_contact(self, queryset, name, value):
+        if value == "yes":
+            return queryset.exclude(emails="")
+        if value == "no":
+            return queryset.filter(emails="")
+
+        return queryset
+
+    def filter_posted_within(self, queryset, name, value):
+        if not value:
+            return queryset
+
+        try:
+            days = int(value)
+        except (TypeError, ValueError):
+            return queryset
+
+        return queryset.filter(submitted_datetime__gte=timezone.now() - timedelta(days=days))
+
+    def filter_salary_floor(self, queryset, name, value):
+        if value in EMPTY_VALUES or value <= 0:
+            return queryset
+
+        return queryset.filter(max_salary__gte=value).exclude(max_salary=0)
+
+    def filter_work_mode(self, queryset, name, value):
+        if value == "remote":
+            return queryset.filter(is_remote=True)
+        if value == "remote_only":
+            return queryset.filter(is_remote=True, is_onsite=False)
+        if value == "onsite":
+            return queryset.filter(is_onsite=True)
+        if value == "onsite_only":
+            return queryset.filter(is_remote=False, is_onsite=True)
+        if value == "hybrid":
+            return queryset.filter(is_remote=True, is_onsite=True)
+
+        return queryset
 
     def extend_technology_search(self, queryset, name, selected_technologies):
         start_time = time.time()
@@ -171,8 +279,9 @@ class PostFilter(FilterSet):
         if self.data.get("vector"):
             self.filters["o"] = PostOrderingFilter(
                 choices=(
-                    ("-submitted_datetime", "Date"),
-                    ("-max_salary", "Max Salary"),
-                    ("-distance", "Relevance"),
+                    ("-submitted_datetime", "Newest first"),
+                    ("-max_salary", "Highest salary"),
+                    ("company__name", "Company A-Z"),
+                    ("distance", "Intent match"),
                 ),
             )

--- a/jobs/tests.py
+++ b/jobs/tests.py
@@ -166,6 +166,21 @@ class FilterSummaryTests(SimpleTestCase):
             "Missing Contact Information",
         ]
 
+    def test_remove_duplicate_employers_is_shown_as_active_and_used_for_metadata(self):
+        query_params = QueryDict("remove_duplicate_employers=true")
+        now = timezone.now()
+
+        assert active_filter_summary(query_params) == [
+            {
+                "label": "Employers",
+                "param": "remove_duplicate_employers",
+                "value": "true",
+                "display": "Unique only",
+            }
+        ]
+        assert generate_job_search_title(query_params, now) == f"Unique Employer Jobs - {now.strftime('%B %Y')}"
+        assert generate_job_search_keywords(query_params) == ["Unique employers"]
+
 
 class CreateIntentAlertsViewTests(TestCase):
     def setUp(self):
@@ -268,7 +283,7 @@ class CompanyEmailMergeTests(SimpleTestCase):
         assert len(merge_company_emails("", long_email_blob)) == MAX_COMPANY_EMAILS_LENGTH
 
 
-class PostFilterTests(TestCase):
+class EmployerDedupeFilterTests(TestCase):
     def test_remove_duplicate_employers_keeps_latest_post_per_employer(self):
         now = timezone.now()
         acme = Company.objects.create(name="Acme")

--- a/jobs/tests.py
+++ b/jobs/tests.py
@@ -6,6 +6,7 @@ from allauth.account.models import EmailAddress
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.db import IntegrityError
+from django.http import QueryDict
 from django.test import SimpleTestCase, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -43,9 +44,12 @@ from jobs.utils import (
     build_intent_alert_suggestions,
     canonical_filter_key,
     clean_job_json_object,
+    generate_job_search_keywords,
+    generate_job_search_title,
     is_probably_non_hiring_hn_comment,
     normalize_hn_comment_text,
 )
+from jobs.views import active_filter_summary, build_serializable_filter_params
 
 
 class PopularQueryTests(TestCase):
@@ -138,6 +142,29 @@ class IntentAlertSuggestionTests(TestCase):
         second_key = canonical_filter_key({"titles": ["3"], "technologies": ["1", "2"]})
 
         assert first_key == second_key
+
+
+class FilterSummaryTests(SimpleTestCase):
+    def test_salary_floor_zero_is_not_serialized_or_shown_as_active(self):
+        query_params = QueryDict("salary_floor=0")
+
+        assert build_serializable_filter_params(query_params) == {}
+        assert active_filter_summary(query_params) == []
+
+    def test_salary_floor_zero_is_not_used_for_metadata(self):
+        query_params = QueryDict("salary_floor=0")
+        now = timezone.now()
+
+        assert generate_job_search_title(query_params, now) == f"Available Jobs - {now.strftime('%B %Y')}"
+        assert generate_job_search_keywords(query_params) == []
+
+    def test_missing_compensation_and_contact_are_metadata_keywords(self):
+        query_params = QueryDict("has_compensation=no&has_contact=no")
+
+        assert generate_job_search_keywords(query_params) == [
+            "Missing Compensation Information",
+            "Missing Contact Information",
+        ]
 
 
 class CreateIntentAlertsViewTests(TestCase):
@@ -666,12 +693,28 @@ class PostFilterTests(TestCase):
         assert self.filtered_ids({"q": "django"}) == {self.remote_post.id}
         assert self.filtered_ids({"q": "react"}) == {self.onsite_post.id}
 
+    def test_keyword_search_ignores_raw_original_text(self):
+        self.onsite_post.original_text = "raw-only-zebra"
+        self.onsite_post.save(update_fields=["original_text"])
+
+        assert self.filtered_ids({"q": "raw-only-zebra"}) == set()
+
+    def test_keyword_search_caps_number_of_terms(self):
+        assert self.filtered_ids({"q": "Acme Build Django APIs data unmatched"}) == {self.remote_post.id}
+
     def test_work_mode_remote_only_excludes_hybrid_roles(self):
         assert self.filtered_ids({"work_mode": "remote_only"}) == {self.remote_post.id}
         assert self.filtered_ids({"work_mode": "remote"}) == {self.remote_post.id, self.hybrid_post.id}
 
     def test_salary_floor_uses_max_salary_range(self):
         assert self.filtered_ids({"salary_floor": "150000"}) == {self.remote_post.id, self.hybrid_post.id}
+
+    def test_salary_floor_zero_is_noop(self):
+        assert self.filtered_ids({"salary_floor": "0"}) == {
+            self.remote_post.id,
+            self.onsite_post.id,
+            self.hybrid_post.id,
+        }
 
     def test_has_compensation_and_contact_filters(self):
         assert self.filtered_ids({"has_compensation": "no"}) == {self.onsite_post.id}
@@ -682,6 +725,17 @@ class PostFilterTests(TestCase):
 
     def test_source_filter_limits_by_job_source(self):
         assert self.filtered_ids({"source": PostSource.REMOTE_OK}) == {self.onsite_post.id}
+
+
+class PostListViewTests(TestCase):
+    def test_filter_context_exposes_source_choices(self):
+        company = Company.objects.create(name="Acme")
+        Post.objects.create(company=company, submitted_datetime=timezone.now(), description="Build software.")
+
+        response = self.client.get(reverse("posts"))
+
+        assert response.status_code == 200
+        assert list(response.context["source_choices"]) == list(PostSource.choices)
 
 
 class RemoteOkImportTests(TestCase):

--- a/jobs/tests.py
+++ b/jobs/tests.py
@@ -597,6 +597,93 @@ class WeWorkRemotelyParsingTests(SimpleTestCase):
         assert data["company_job_application_link"] == "https://weworkremotely.com/remote-jobs/acme-python-engineer"
 
 
+class PostFilterTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        now = timezone.now()
+        cls.python = Technology.objects.create(name="Python")
+        cls.react = Technology.objects.create(name="React")
+        cls.backend = Title.objects.create(name="Backend Engineer")
+        cls.frontend = Title.objects.create(name="Frontend Engineer")
+
+        acme = Company.objects.create(name="Acme", company_homepage_link="https://example.com")
+        beta = Company.objects.create(name="Beta", company_homepage_link="https://example.org")
+        gamma = Company.objects.create(name="Gamma", company_homepage_link="https://example.net")
+
+        cls.remote_post = Post.objects.create(
+            submitted_datetime=now,
+            company=acme,
+            description="Build Django APIs for data teams.",
+            original_text="Python and Django role",
+            compensation_summary="$150k - $180k",
+            min_salary=150000,
+            max_salary=180000,
+            locations="Remote US",
+            is_remote=True,
+            is_onsite=False,
+            emails="lead@example.com",
+            source=PostSource.HACKER_NEWS,
+        )
+        cls.remote_post.technologies.add(cls.python)
+        cls.remote_post.titles.add(cls.backend)
+
+        cls.onsite_post = Post.objects.create(
+            submitted_datetime=now - timezone.timedelta(days=2),
+            company=beta,
+            description="React product work in Berlin.",
+            original_text="Frontend role",
+            compensation_summary="",
+            min_salary=90000,
+            max_salary=130000,
+            locations="Berlin, Germany",
+            is_remote=False,
+            is_onsite=True,
+            emails="",
+            source=PostSource.REMOTE_OK,
+        )
+        cls.onsite_post.technologies.add(cls.react)
+        cls.onsite_post.titles.add(cls.frontend)
+
+        cls.hybrid_post = Post.objects.create(
+            submitted_datetime=now - timezone.timedelta(days=90),
+            company=gamma,
+            description="Machine learning platform role.",
+            original_text="Hybrid ML role",
+            compensation_summary="$170k",
+            min_salary=160000,
+            max_salary=170000,
+            locations="New York or remote",
+            is_remote=True,
+            is_onsite=True,
+            emails="",
+            source=PostSource.WE_WORK_REMOTELY,
+        )
+
+    def filtered_ids(self, params):
+        return set(PostFilter(params, queryset=Post.objects.all()).qs.values_list("id", flat=True))
+
+    def test_keyword_search_matches_joined_job_fields(self):
+        assert self.filtered_ids({"q": "django"}) == {self.remote_post.id}
+        assert self.filtered_ids({"q": "react"}) == {self.onsite_post.id}
+
+    def test_work_mode_remote_only_excludes_hybrid_roles(self):
+        assert self.filtered_ids({"work_mode": "remote_only"}) == {self.remote_post.id}
+        assert self.filtered_ids({"work_mode": "remote"}) == {self.remote_post.id, self.hybrid_post.id}
+
+    def test_salary_floor_uses_max_salary_range(self):
+        assert self.filtered_ids({"salary_floor": "150000"}) == {self.remote_post.id, self.hybrid_post.id}
+
+    def test_has_compensation_and_contact_filters(self):
+        assert self.filtered_ids({"has_compensation": "no"}) == {self.onsite_post.id}
+        assert self.filtered_ids({"has_contact": "yes"}) == {self.remote_post.id}
+
+    def test_posted_within_filters_by_submitted_datetime(self):
+        assert self.filtered_ids({"posted_within": "30"}) == {self.remote_post.id, self.onsite_post.id}
+
+    def test_source_filter_limits_by_job_source(self):
+        assert self.filtered_ids({"source": PostSource.REMOTE_OK}) == {self.onsite_post.id}
+
+
 class RemoteOkImportTests(TestCase):
     @patch("jobs.tasks.get_embedding", return_value=[0.0] * 1536)
     @patch("jobs.tasks.extract_job_data_from_text")

--- a/jobs/utils.py
+++ b/jobs/utils.py
@@ -1,6 +1,7 @@
 import json
 import re
 from datetime import datetime
+from decimal import Decimal, InvalidOperation
 from html import unescape
 from itertools import combinations
 
@@ -437,12 +438,30 @@ def is_email_confirmed(user):
         return False
 
 
+def is_positive_salary_floor(value):
+    try:
+        salary_floor = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return False
+
+    return salary_floor > 0
+
+
+def has_meaningful_filter_value(query_params, key):
+    values = [value for value in query_params.getlist(key) if value not in ["", "unknown"]]
+
+    if key == "salary_floor":
+        return any(is_positive_salary_floor(value) for value in values)
+
+    return bool(values)
+
+
 def generate_job_search_title(query_params, first_item_datetime):
     date = first_item_datetime.strftime("%B %Y")
     meaningful_keys = [
         key
         for key in query_params.keys()
-        if key not in {"o", "page"} and any(value not in ["", "unknown"] for value in query_params.getlist(key))
+        if key not in {"o", "page"} and has_meaningful_filter_value(query_params, key)
     ]
 
     if len(meaningful_keys) > 1 or len(meaningful_keys) == 0:
@@ -459,7 +478,7 @@ def generate_job_search_title(query_params, first_item_datetime):
     if query_param == "posted_within":
         return f"Jobs from the last {query_params['posted_within']} days - {date}"
 
-    if query_param == "salary_floor":
+    if query_param == "salary_floor" and is_positive_salary_floor(query_params["salary_floor"]):
         return f"Jobs paying at least {query_params['salary_floor']} - {date}"
 
     if query_param == "work_mode":
@@ -534,7 +553,7 @@ def generate_job_search_keywords(query_params):
         if key == "posted_within":
             keywords.append(f"Last {query_params['posted_within']} days")
 
-        if key == "salary_floor":
+        if key == "salary_floor" and is_positive_salary_floor(query_params["salary_floor"]):
             keywords.append(f"Salary at least {query_params['salary_floor']}")
 
         if key == "work_mode":
@@ -547,11 +566,17 @@ def generate_job_search_keywords(query_params):
             }
             keywords.append(work_mode_keywords.get(query_params["work_mode"], query_params["work_mode"]))
 
-        if key == "has_compensation" and query_params["has_compensation"] == "yes":
-            keywords.append("Compensation Information")
+        if key == "has_compensation":
+            if query_params["has_compensation"] == "yes":
+                keywords.append("Compensation Information")
+            if query_params["has_compensation"] == "no":
+                keywords.append("Missing Compensation Information")
 
-        if key == "has_contact" and query_params["has_contact"] == "yes":
-            keywords.append("Contact Information")
+        if key == "has_contact":
+            if query_params["has_contact"] == "yes":
+                keywords.append("Contact Information")
+            if query_params["has_contact"] == "no":
+                keywords.append("Missing Contact Information")
 
         if key == "technologies":
             technologies_list = query_params.getlist("technologies")
@@ -572,11 +597,17 @@ def generate_job_search_keywords(query_params):
         if key == "locations":
             keywords.append(query_params["locations"])
 
-        if key == "compensation_summary__isempty" and query_params["compensation_summary__isempty"] == "true":
-            keywords.append("Compensation Information")
+        if key == "compensation_summary__isempty":
+            if query_params["compensation_summary__isempty"] == "true":
+                keywords.append("Compensation Information")
+            if query_params["compensation_summary__isempty"] == "false":
+                keywords.append("Missing Compensation Information")
 
-        if key == "emails__isempty" and query_params["emails__isempty"] == "true":
-            keywords.append("Contact Information")
+        if key == "emails__isempty":
+            if query_params["emails__isempty"] == "true":
+                keywords.append("Contact Information")
+            if query_params["emails__isempty"] == "false":
+                keywords.append("Missing Contact Information")
 
         if key == "is_remote" and query_params["is_remote"] == "true":
             keywords.append("Remote")

--- a/jobs/utils.py
+++ b/jobs/utils.py
@@ -439,22 +439,65 @@ def is_email_confirmed(user):
 
 def generate_job_search_title(query_params, first_item_datetime):
     date = first_item_datetime.strftime("%B %Y")
-    if len(query_params) > 1 or len(query_params) == 0:
+    meaningful_keys = [
+        key
+        for key in query_params.keys()
+        if key not in {"o", "page"} and any(value not in ["", "unknown"] for value in query_params.getlist(key))
+    ]
+
+    if len(meaningful_keys) > 1 or len(meaningful_keys) == 0:
         return f"Available Jobs - {date}"
 
-    query_param = list(query_params.keys())[0]
+    query_param = meaningful_keys[0]
+
+    if query_param == "q":
+        return f"Jobs matching {query_params['q']} - {date}"
+
+    if query_param == "source":
+        return f"{query_params['source']} Jobs - {date}"
+
+    if query_param == "posted_within":
+        return f"Jobs from the last {query_params['posted_within']} days - {date}"
+
+    if query_param == "salary_floor":
+        return f"Jobs paying at least {query_params['salary_floor']} - {date}"
+
+    if query_param == "work_mode":
+        work_mode_titles = {
+            "remote": "Remote Jobs",
+            "remote_only": "Remote-only Jobs",
+            "onsite": "Onsite and Hybrid Jobs",
+            "onsite_only": "Onsite Jobs",
+            "hybrid": "Hybrid Jobs",
+        }
+        return f"{work_mode_titles.get(query_params['work_mode'], 'Available Jobs')} - {date}"
+
+    if query_param == "has_compensation":
+        compensation_title = (
+            "Compensation Info" if query_params["has_compensation"] == "yes" else "No Compensation Info"
+        )
+        return f"Jobs with {compensation_title} - {date}"
+
+    if query_param == "has_contact":
+        return f"Jobs with {'Contact Info' if query_params['has_contact'] == 'yes' else 'No Contact Info'} - {date}"
 
     if query_param == "technologies":
         technologies_list = query_params.getlist("technologies")
         if len(technologies_list) == 1:
-            tech_name = Technology.objects.get(id=query_params.getlist("technologies")[0]).name
-            return f"{tech_name} Jobs - {date}"
+            try:
+                tech_name = Technology.objects.get(id=query_params.getlist("technologies")[0]).name
+                return f"{tech_name} Jobs - {date}"
+            except (Technology.DoesNotExist, ValueError):
+                return f"Available Jobs - {date}"
 
     if query_param == "titles":
         titles_list = query_params.getlist("titles")
         if len(titles_list) == 1:
-            title_name = Title.objects.get(id=query_params.getlist("titles")[0]).name
-            return f"{title_name} Jobs - {date}"
+            try:
+                title_name = Title.objects.get(id=query_params.getlist("titles")[0]).name
+                return f"{title_name} Jobs - {date}"
+            except (Title.DoesNotExist, ValueError):
+                return f"Available Jobs - {date}"
 
     if query_param == "locations":
         return f"Jobs in {query_params['locations']} - {date}"
@@ -482,15 +525,49 @@ def generate_job_search_keywords(query_params):
     keywords = []
 
     for key in query_params.keys():
+        if key == "q":
+            keywords.append(query_params["q"])
+
+        if key == "source":
+            keywords.append(query_params["source"])
+
+        if key == "posted_within":
+            keywords.append(f"Last {query_params['posted_within']} days")
+
+        if key == "salary_floor":
+            keywords.append(f"Salary at least {query_params['salary_floor']}")
+
+        if key == "work_mode":
+            work_mode_keywords = {
+                "remote": "Remote",
+                "remote_only": "Remote only",
+                "onsite": "Onsite or hybrid",
+                "onsite_only": "Onsite only",
+                "hybrid": "Hybrid",
+            }
+            keywords.append(work_mode_keywords.get(query_params["work_mode"], query_params["work_mode"]))
+
+        if key == "has_compensation" and query_params["has_compensation"] == "yes":
+            keywords.append("Compensation Information")
+
+        if key == "has_contact" and query_params["has_contact"] == "yes":
+            keywords.append("Contact Information")
+
         if key == "technologies":
             technologies_list = query_params.getlist("technologies")
             for tech_id in technologies_list:
-                keywords.append(Technology.objects.get(id=tech_id).name)
+                try:
+                    keywords.append(Technology.objects.get(id=tech_id).name)
+                except (Technology.DoesNotExist, ValueError):
+                    continue
 
         if key == "titles":
             titles_list = query_params.getlist("titles")
             for title_id in titles_list:
-                keywords.append(Title.objects.get(id=title_id).name)
+                try:
+                    keywords.append(Title.objects.get(id=title_id).name)
+                except (Title.DoesNotExist, ValueError):
+                    continue
 
         if key == "locations":
             keywords.append(query_params["locations"])

--- a/jobs/utils.py
+++ b/jobs/utils.py
@@ -491,6 +491,9 @@ def generate_job_search_title(query_params, first_item_datetime):
         }
         return f"{work_mode_titles.get(query_params['work_mode'], 'Available Jobs')} - {date}"
 
+    if query_param == "remove_duplicate_employers" and query_params["remove_duplicate_employers"] == "true":
+        return f"Unique Employer Jobs - {date}"
+
     if query_param == "has_compensation":
         compensation_title = (
             "Compensation Info" if query_params["has_compensation"] == "yes" else "No Compensation Info"
@@ -565,6 +568,9 @@ def generate_job_search_keywords(query_params):
                 "hybrid": "Hybrid",
             }
             keywords.append(work_mode_keywords.get(query_params["work_mode"], query_params["work_mode"]))
+
+        if key == "remove_duplicate_employers" and query_params["remove_duplicate_employers"] == "true":
+            keywords.append("Unique employers")
 
         if key == "has_compensation":
             if query_params["has_compensation"] == "yes":

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -1,5 +1,6 @@
 import json
 from datetime import timedelta
+from decimal import Decimal, InvalidOperation
 from uuid import UUID
 
 from django.contrib import messages
@@ -23,7 +24,7 @@ from hn_jobs.posthog_events import capture_event, capture_request_event, distinc
 from hn_jobs.utils import add_users_context, build_absolute_site_url, get_tjalerts_logger, validate_technology_selected
 from jobs.choices import PostSource
 from jobs.constants import EXCLUDED_TECHNOLOGIES, EXCLUDED_TITLES
-from jobs.filters import HAS_FIELD_CHOICES, POSTED_WITHIN_CHOICES, WORK_MODE_CHOICES, PostFilter
+from jobs.filters import POSTED_WITHIN_CHOICES, WORK_MODE_CHOICES, PostFilter
 from jobs.forms import ConfirmAlertForm, CreateAlertForm, CreateCustomAlertForm, CreateIntentAlertForm
 from jobs.models import Alert, AlertEmailSend, Company, Post, Technology, TechnologyMapping, Title
 from jobs.tasks import (
@@ -51,7 +52,7 @@ excluded_tech = Technology.objects.filter(name__in=EXCLUDED_TECHNOLOGIES)
 excluded_titles = Title.objects.filter(name__in=EXCLUDED_TITLES)
 
 YES_NO_LABELS = {"true": "Yes", "false": "No"}
-HAS_FIELD_LABELS = {**dict(HAS_FIELD_CHOICES), "yes": "Listed", "no": "Missing"}
+HAS_FIELD_LABELS = {"yes": "Listed", "no": "Missing"}
 POSTED_WITHIN_LABELS = dict(POSTED_WITHIN_CHOICES)
 SOURCE_LABELS = dict(PostSource.choices)
 WORK_MODE_LABELS = dict(WORK_MODE_CHOICES)
@@ -78,6 +79,8 @@ def build_serializable_filter_params(query_params):
             continue
 
         values = [value for value in query_params.getlist(key) if value not in ["", "unknown"]]
+        if key == "salary_floor":
+            values = [value for value in values if parse_positive_salary_floor(value) is not None]
         if not values:
             continue
 
@@ -86,11 +89,21 @@ def build_serializable_filter_params(query_params):
     return params
 
 
-def salary_label(value):
+def parse_positive_salary_floor(value):
     try:
-        return f"${int(value):,}+"
-    except (TypeError, ValueError):
+        salary_floor = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+
+    return salary_floor if salary_floor > 0 else None
+
+
+def salary_label(value):
+    salary_floor = parse_positive_salary_floor(value)
+    if salary_floor is None:
         return value
+
+    return f"${int(salary_floor):,}+"
 
 
 def active_filter_summary(query_params):
@@ -124,13 +137,13 @@ def active_filter_summary(query_params):
             }
         )
 
-    salary_floor = query_params.get("salary_floor")
-    if salary_floor:
+    salary_floor = parse_positive_salary_floor(query_params.get("salary_floor"))
+    if salary_floor is not None:
         filters.append(
             {
                 "label": "Salary",
                 "param": "salary_floor",
-                "value": salary_floor,
+                "value": query_params.get("salary_floor"),
                 "display": salary_label(salary_floor),
             }
         )
@@ -184,6 +197,10 @@ class PostListView(FilterView):
                 del query_params[key]
                 needs_redirect = True
 
+        if "salary_floor" in query_params and parse_positive_salary_floor(query_params.get("salary_floor")) is None:
+            del query_params["salary_floor"]
+            needs_redirect = True
+
         if needs_redirect:
             clean_url = f"{reverse('posts')}?{query_params.urlencode()}"
             return HttpResponseRedirect(clean_url)
@@ -219,6 +236,7 @@ class PostListView(FilterView):
         context["active_filters"] = active_filters
         context["active_filter_count"] = len(active_filters)
         context["result_count"] = page.paginator.count
+        context["source_choices"] = PostSource.choices
         context["title"] = title
         context["date"] = date
         context["keywords"] = ", ".join(map(str, keywords))

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -1,4 +1,6 @@
+import json
 from datetime import timedelta
+from uuid import UUID
 
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
@@ -19,8 +21,9 @@ from django_q.tasks import async_task
 
 from hn_jobs.posthog_events import capture_event, capture_request_event, distinct_id_for_email
 from hn_jobs.utils import add_users_context, build_absolute_site_url, get_tjalerts_logger, validate_technology_selected
+from jobs.choices import PostSource
 from jobs.constants import EXCLUDED_TECHNOLOGIES, EXCLUDED_TITLES
-from jobs.filters import PostFilter
+from jobs.filters import HAS_FIELD_CHOICES, POSTED_WITHIN_CHOICES, WORK_MODE_CHOICES, PostFilter
 from jobs.forms import ConfirmAlertForm, CreateAlertForm, CreateCustomAlertForm, CreateIntentAlertForm
 from jobs.models import Alert, AlertEmailSend, Company, Post, Technology, TechnologyMapping, Title
 from jobs.tasks import (
@@ -46,6 +49,121 @@ logger = get_tjalerts_logger(__name__)
 
 excluded_tech = Technology.objects.filter(name__in=EXCLUDED_TECHNOLOGIES)
 excluded_titles = Title.objects.filter(name__in=EXCLUDED_TITLES)
+
+YES_NO_LABELS = {"true": "Yes", "false": "No"}
+HAS_FIELD_LABELS = {**dict(HAS_FIELD_CHOICES), "yes": "Listed", "no": "Missing"}
+POSTED_WITHIN_LABELS = dict(POSTED_WITHIN_CHOICES)
+SOURCE_LABELS = dict(PostSource.choices)
+WORK_MODE_LABELS = dict(WORK_MODE_CHOICES)
+
+
+def valid_uuid_values(values):
+    valid_values = []
+
+    for value in values:
+        try:
+            UUID(str(value))
+        except (TypeError, ValueError):
+            continue
+        valid_values.append(value)
+
+    return valid_values
+
+
+def build_serializable_filter_params(query_params):
+    params = {}
+
+    for key in query_params.keys():
+        if key in {"o", "page"}:
+            continue
+
+        values = [value for value in query_params.getlist(key) if value not in ["", "unknown"]]
+        if not values:
+            continue
+
+        params[key] = values if len(values) > 1 or key in {"technologies", "titles"} else values[0]
+
+    return params
+
+
+def salary_label(value):
+    try:
+        return f"${int(value):,}+"
+    except (TypeError, ValueError):
+        return value
+
+
+def active_filter_summary(query_params):
+    filters = []
+
+    simple_filters = {
+        "q": ("Search", None),
+        "vector": ("Intent", None),
+        "locations": ("Location", None),
+        "source": ("Source", SOURCE_LABELS),
+        "posted_within": ("Posted", POSTED_WITHIN_LABELS),
+        "work_mode": ("Work", WORK_MODE_LABELS),
+        "has_compensation": ("Comp", HAS_FIELD_LABELS),
+        "has_contact": ("Contact", HAS_FIELD_LABELS),
+        "is_remote": ("Remote", YES_NO_LABELS),
+        "is_onsite": ("Onsite", YES_NO_LABELS),
+        "compensation_summary__isempty": ("Comp", {"true": "Listed", "false": "Missing"}),
+        "emails__isempty": ("Contact", {"true": "Listed", "false": "Missing"}),
+    }
+
+    for param, (label, value_labels) in simple_filters.items():
+        value = query_params.get(param)
+        if not value or value == "unknown":
+            continue
+        filters.append(
+            {
+                "label": label,
+                "param": param,
+                "value": value,
+                "display": value_labels.get(value, value) if value_labels else value,
+            }
+        )
+
+    salary_floor = query_params.get("salary_floor")
+    if salary_floor:
+        filters.append(
+            {
+                "label": "Salary",
+                "param": "salary_floor",
+                "value": salary_floor,
+                "display": salary_label(salary_floor),
+            }
+        )
+
+    technology_ids = valid_uuid_values(query_params.getlist("technologies"))
+    if technology_ids:
+        technologies_by_id = {
+            str(technology.id): technology.name for technology in Technology.objects.filter(id__in=technology_ids)
+        }
+        for technology_id in technology_ids:
+            filters.append(
+                {
+                    "label": "Tech",
+                    "param": "technologies",
+                    "value": technology_id,
+                    "display": technologies_by_id.get(str(technology_id), technology_id),
+                }
+            )
+
+    title_ids = valid_uuid_values(query_params.getlist("titles"))
+    if title_ids:
+        titles_by_id = {str(title.id): title.name for title in Title.objects.filter(id__in=title_ids)}
+        for title_id in title_ids:
+            filters.append(
+                {
+                    "label": "Role",
+                    "param": "titles",
+                    "value": title_id,
+                    "display": titles_by_id.get(str(title_id), title_id),
+                }
+            )
+
+    return filters
 
 
 class PostListView(FilterView):
@@ -92,6 +210,15 @@ class PostListView(FilterView):
         if user.is_authenticated:
             add_users_context(context, user, self)
 
+        params = build_serializable_filter_params(self.request.GET)
+        active_filters = active_filter_summary(self.request.GET)
+
+        context["CustomAlertForm"] = CreateCustomAlertForm
+        context["custom_alert_filters"] = json.dumps(params)
+        context["has_custom_alert_filters"] = bool(params)
+        context["active_filters"] = active_filters
+        context["active_filter_count"] = len(active_filters)
+        context["result_count"] = page.paginator.count
         context["title"] = title
         context["date"] = date
         context["keywords"] = ", ".join(map(str, keywords))

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -116,6 +116,7 @@ def active_filter_summary(query_params):
         "source": ("Source", SOURCE_LABELS),
         "posted_within": ("Posted", POSTED_WITHIN_LABELS),
         "work_mode": ("Work", WORK_MODE_LABELS),
+        "remove_duplicate_employers": ("Employers", {"true": "Unique only"}),
         "has_compensation": ("Comp", HAS_FIELD_LABELS),
         "has_contact": ("Contact", HAS_FIELD_LABELS),
         "is_remote": ("Remote", YES_NO_LABELS),

--- a/templates/jobs/all_jobs.html
+++ b/templates/jobs/all_jobs.html
@@ -33,7 +33,7 @@
     <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
       <div>
         <h1 class="app-title">{{ title }}</h1>
-        <p class="app-subtitle">Filter Hacker News hiring posts by stack, title, location, remote work, compensation, and contact info.</p>
+        <p class="app-subtitle">Search by company, role, stack, location, salary signal, source, and work setup.</p>
       </div>
       <div class="flex flex-wrap gap-2">
         <a href="{% url 'posts' %}" class="btn-secondary">Reset filters</a>
@@ -43,146 +43,271 @@
 </div>
 
 <div class="app-container py-6 sm:py-8">
-  <div class="grid gap-6 lg:grid-cols-[320px_minmax(0,1fr)]">
-    <aside class="lg:sticky lg:top-24 lg:self-start">
-      <form method="get" class="app-panel space-y-5">
-        <div>
-          <h2 class="text-base font-semibold text-zinc-950">Filters</h2>
-          <p class="mt-1 text-sm leading-6 text-zinc-600">Refine the open database by stack, title, location, remote status, compensation, and contact info.</p>
-        </div>
+  <form id="job-filter-form" method="get" class="filter-panel">
+    <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+      <div>
+        <h2 class="text-base font-semibold text-zinc-950">Filter jobs</h2>
+        <p class="mt-1 max-w-3xl text-sm leading-6 text-zinc-600">Start with search, then tighten by role, stack, work setup, salary, source, and recency.</p>
+      </div>
+      {% if active_filter_count %}
+        <span class="filter-count">{{ active_filter_count }} active</span>
+      {% endif %}
+    </div>
 
-        <div>
-          <label for="order" class="app-label">Sort by</label>
-          {% render_field filter.form.o id="order" name="order" class="app-select mt-1" %}
-        </div>
-
-        <div>
-          <label for="vector" class="app-label">Search</label>
-          {% render_field filter.form.vector id="vector" placeholder="e.g. green tech" name="vector" class="app-input mt-1" %}
-        </div>
-
-        <div>
-          <label for="locations" class="app-label">Location</label>
-          {% render_field filter.form.locations id="locations" placeholder="e.g. New York" name="locations" class="app-input mt-1" %}
-        </div>
-
-        <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-1">
-          <div>
-            <label for="compensation_summary__isempty" class="app-label">Compensation</label>
-            {% render_field filter.form.compensation_summary__isempty id="compensation_summary__isempty" name="compensation_summary__isempty" class="app-select mt-1" %}
-          </div>
-          <div>
-            <label for="emails__isempty" class="app-label">Contact info</label>
-            {% render_field filter.form.emails__isempty id="emails__isempty" name="emails__isempty" class="app-select mt-1" %}
-          </div>
-          <div>
-            <label for="remove_duplicate_employers" class="app-label">Employers</label>
-            {% render_field filter.form.remove_duplicate_employers id="remove_duplicate_employers" name="remove_duplicate_employers" class="app-select mt-1" %}
-          </div>
-          <div>
-            <label for="is_remote" class="app-label">Remote</label>
-            {% render_field filter.form.is_remote id="is_remote" name="is_remote" class="app-select mt-1" %}
-          </div>
-          <div>
-            <label for="is_onsite" class="app-label">Onsite</label>
-            {% render_field filter.form.is_onsite id="is_onsite" name="is_onsite" class="app-select mt-1" %}
-          </div>
-        </div>
-
-        <div
-          data-controller="reveal search-and-select"
-          data-search-and-select-search-url-value="/api/technologies/search"
-          data-search-and-select-detail-url-value="/api/technology"
-          data-search-and-select-type-value="technologies"
-          class="border-t border-zinc-200 pt-5"
-        >
-          <button type="button" class="flex w-full items-center justify-between rounded-md p-2 text-left hover:bg-zinc-100" data-action="click->reveal#toggle">
-            <span class="app-label">Tech stack</span>
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor" class="h-4 w-4 text-zinc-500">
-              <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
-            </svg>
-          </button>
-          <div data-reveal-target="item" class="mt-2">
-            <input
-              type="text"
-              data-search-and-select-target="search"
-              data-action="input->search-and-select#search"
-              placeholder="Search technologies"
-              class="app-input"
-            />
-            <div data-search-and-select-target="selectedResults" class="my-2"></div>
-            <div data-search-and-select-target="searchResults" class="max-h-64 overflow-auto rounded-md"></div>
-          </div>
-        </div>
-
-        <div
-          data-controller="reveal search-and-select"
-          data-search-and-select-search-url-value="/api/title/search"
-          data-search-and-select-detail-url-value="/api/title"
-          data-search-and-select-type-value="titles"
-          class="border-t border-zinc-200 pt-5"
-        >
-          <button type="button" class="flex w-full items-center justify-between rounded-md p-2 text-left hover:bg-zinc-100" data-action="click->reveal#toggle">
-            <span class="app-label">Title</span>
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor" class="h-4 w-4 text-zinc-500">
-              <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
-            </svg>
-          </button>
-          <div data-reveal-target="item" class="mt-2">
-            <input
-              type="text"
-              data-search-and-select-target="search"
-              data-action="input->search-and-select#search"
-              placeholder="Search titles"
-              class="app-input"
-            />
-            <div data-search-and-select-target="selectedResults" class="my-2"></div>
-            <div data-search-and-select-target="searchResults" class="max-h-64 overflow-auto rounded-md"></div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-2 border-t border-zinc-200 pt-5">
-          <a href="{% url 'posts' %}" class="btn-secondary">Reset</a>
-          <button type="submit" class="btn-primary">Filter</button>
-        </div>
-      </form>
-    </aside>
-
-    <section aria-label="Job results">
-      <div class="mb-4 flex items-center justify-between gap-4">
-        <p class="text-sm text-zinc-600">
-          Page <span class="tabular font-medium text-zinc-950">{{ page_obj.number }}</span> of
-          <span class="tabular font-medium text-zinc-950">{{ page_obj.paginator.num_pages }}</span>
-        </p>
+    <div class="grid gap-4 lg:grid-cols-2">
+      <div>
+        <label for="q" class="app-label">Keyword search</label>
+        <input
+          type="search"
+          id="q"
+          name="q"
+          value="{{ request.GET.q }}"
+          placeholder="company, skill, title, or keyword"
+          class="app-input mt-2"
+        />
+        <p class="app-help mt-2">Matches company, description, role, stack, location, and compensation text.</p>
       </div>
 
-      <ul role="list" class="space-y-3">
-        {% for object in page_obj %}
-          {% include "components/job-posting.html" with object=object show_name=True %}
-        {% empty %}
-        <li class="empty-state">
-          <h2 class="text-lg font-semibold text-zinc-950">No jobs match these filters</h2>
-          <p class="mx-auto mt-2 max-w-md text-sm leading-6 text-zinc-600">Try removing one filter or broadening the search terms.</p>
-          <a href="{% url 'posts' %}" class="btn-secondary mt-5">Clear filters</a>
-        </li>
-      {% endfor %}
-      </ul>
+      <div>
+        <label for="vector" class="app-label">Intent match</label>
+        {% render_field filter.form.vector id="vector" placeholder="e.g. climate fintech backend" name="vector" class="app-input mt-2" %}
+        <p class="app-help mt-2">Semantic search for fuzzy concepts. Use keywords for exact matches.</p>
+      </div>
+    </div>
 
-      <nav class="mt-6 flex items-center justify-between" aria-label="Pagination">
-        <div>
-          {% if page_obj.has_previous %}
-          <a href="?{% url_replace request 'page' page_obj.previous_page_number %}" class="btn-secondary">Previous</a>
-          {% endif %}
+    <div class="filter-section grid gap-4 lg:grid-cols-2">
+      <div
+        data-controller="search-and-select"
+        data-search-and-select-search-url-value="/api/technologies/search"
+        data-search-and-select-detail-url-value="/api/technology"
+        data-search-and-select-type-value="technologies"
+      >
+        <label for="technology-search" class="app-label">Tech stack</label>
+        <p class="app-help mt-1">Pick one or more technologies. Parent stacks include related child tools.</p>
+        <div class="mt-3">
+          <input
+            id="technology-search"
+            type="text"
+            data-search-and-select-target="search"
+            data-action="input->search-and-select#search"
+            placeholder="Search technologies"
+            class="app-input"
+          />
+          <div data-search-and-select-target="selectedResults" class="selected-filter-list"></div>
+          <div data-search-and-select-target="searchResults" class="filter-search-results"></div>
         </div>
+      </div>
 
-        <div>
-          {% if page_obj.has_next %}
-          <a href="?{% url_replace request 'page' page_obj.next_page_number %}" class="btn-primary">Next</a>
-          {% endif %}
+      <div
+        data-controller="search-and-select"
+        data-search-and-select-search-url-value="/api/title/search"
+        data-search-and-select-detail-url-value="/api/title"
+        data-search-and-select-type-value="titles"
+      >
+        <label for="title-search" class="app-label">Role</label>
+        <p class="app-help mt-1">Use role tags when keywords are too loose.</p>
+        <div class="mt-3">
+          <input
+            id="title-search"
+            type="text"
+            data-search-and-select-target="search"
+            data-action="input->search-and-select#search"
+            placeholder="Search roles"
+            class="app-input"
+          />
+          <div data-search-and-select-target="selectedResults" class="selected-filter-list"></div>
+          <div data-search-and-select-target="searchResults" class="filter-search-results"></div>
         </div>
-      </nav>
-    </section>
+      </div>
+    </div>
+
+    <fieldset class="filter-section">
+      <legend class="app-label">Work setup</legend>
+      <div class="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-6">
+        <label class="filter-choice">
+          <input type="radio" name="work_mode" value="" {% if not request.GET.work_mode and request.GET.is_remote != "true" and request.GET.is_onsite != "true" %}checked{% endif %} />
+          <span>Any</span>
+        </label>
+        <label class="filter-choice">
+          <input type="radio" name="work_mode" value="remote" {% if request.GET.work_mode == "remote" or request.GET.is_remote == "true" %}checked{% endif %} />
+          <span>Remote roles</span>
+        </label>
+        <label class="filter-choice">
+          <input type="radio" name="work_mode" value="remote_only" {% if request.GET.work_mode == "remote_only" %}checked{% endif %} />
+          <span>Remote only</span>
+        </label>
+        <label class="filter-choice">
+          <input type="radio" name="work_mode" value="hybrid" {% if request.GET.work_mode == "hybrid" %}checked{% endif %} />
+          <span>Hybrid</span>
+        </label>
+        <label class="filter-choice">
+          <input type="radio" name="work_mode" value="onsite" {% if request.GET.work_mode == "onsite" or request.GET.is_onsite == "true" %}checked{% endif %} />
+          <span>Onsite roles</span>
+        </label>
+        <label class="filter-choice">
+          <input type="radio" name="work_mode" value="onsite_only" {% if request.GET.work_mode == "onsite_only" %}checked{% endif %} />
+          <span>Onsite only</span>
+        </label>
+      </div>
+    </fieldset>
+
+    <div class="filter-section grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <div>
+        <label for="locations" class="app-label">Location</label>
+        {% render_field filter.form.locations id="locations" placeholder="city, country, region, timezone" name="locations" class="app-input mt-2" %}
+      </div>
+      <div>
+        <label for="salary_floor" class="app-label">Salary floor</label>
+        <input
+          type="number"
+          id="salary_floor"
+          name="salary_floor"
+          min="0"
+          step="10000"
+          inputmode="numeric"
+          value="{{ request.GET.salary_floor }}"
+          placeholder="150000"
+          class="app-input mt-2"
+        />
+      </div>
+      <div>
+        <label for="has_compensation" class="app-label">Compensation</label>
+        <select id="has_compensation" name="has_compensation" class="app-select mt-2">
+          <option value="">Any</option>
+          <option value="yes" {% if request.GET.has_compensation == "yes" or request.GET.compensation_summary__isempty == "true" %}selected{% endif %}>Listed only</option>
+          <option value="no" {% if request.GET.has_compensation == "no" or request.GET.compensation_summary__isempty == "false" %}selected{% endif %}>Missing only</option>
+        </select>
+      </div>
+      <div>
+        <label for="has_contact" class="app-label">Contact info</label>
+        <select id="has_contact" name="has_contact" class="app-select mt-2">
+          <option value="">Any</option>
+          <option value="yes" {% if request.GET.has_contact == "yes" or request.GET.emails__isempty == "true" %}selected{% endif %}>Listed only</option>
+          <option value="no" {% if request.GET.has_contact == "no" or request.GET.emails__isempty == "false" %}selected{% endif %}>Missing only</option>
+        </select>
+      </div>
+      <div>
+        <label for="source" class="app-label">Source</label>
+        <select id="source" name="source" class="app-select mt-2">
+          <option value="">All sources</option>
+          {% for value, label in source_choices %}
+            <option value="{{ value }}" {% if request.GET.source == value %}selected{% endif %}>{{ label }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div>
+        <label for="remove_duplicate_employers" class="app-label">Employers</label>
+        {% render_field filter.form.remove_duplicate_employers id="remove_duplicate_employers" name="remove_duplicate_employers" class="app-select mt-2" %}
+      </div>
+      <div>
+        <label for="posted_within" class="app-label">Posted</label>
+        <select id="posted_within" name="posted_within" class="app-select mt-2">
+          <option value="">Any time</option>
+          <option value="7" {% if request.GET.posted_within == "7" %}selected{% endif %}>Last 7 days</option>
+          <option value="30" {% if request.GET.posted_within == "30" %}selected{% endif %}>Last 30 days</option>
+          <option value="60" {% if request.GET.posted_within == "60" %}selected{% endif %}>Last 60 days</option>
+        </select>
+      </div>
+      <div>
+        <label for="o" class="app-label">Sort by</label>
+        {% render_field filter.form.o id="o" class="app-select mt-2" %}
+      </div>
+      <div class="grid grid-cols-2 gap-2 sm:self-end">
+        <a href="{% url 'posts' %}" class="btn-secondary">Reset</a>
+        <button type="submit" class="btn-primary">Filter</button>
+      </div>
+    </div>
+  </form>
+
+  <div class="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1fr)_340px] lg:items-stretch">
+    <div class="space-y-3">
+      <div class="result-toolbar">
+        <div class="flex flex-col gap-1">
+          <p class="text-sm font-medium text-zinc-950">
+            <span class="tabular">{{ result_count }}</span> matching job{{ result_count|pluralize }}
+          </p>
+          <p class="text-sm text-zinc-600">
+            Page <span class="tabular font-medium text-zinc-950">{{ page_obj.number }}</span> of
+            <span class="tabular font-medium text-zinc-950">{{ page_obj.paginator.num_pages }}</span>
+          </p>
+        </div>
+        {% if active_filter_count %}
+          <a href="{% url 'posts' %}" class="btn-secondary">Clear all</a>
+        {% endif %}
+      </div>
+
+      {% if active_filters %}
+        <div class="active-filter-list" aria-label="Active filters">
+          {% for active in active_filters %}
+            {% url_remove request active.param active.value as remove_query %}
+            <a href="{% url 'posts' %}{% if remove_query %}?{{ remove_query }}{% endif %}" class="active-filter-chip">
+              <span class="font-medium text-zinc-500">{{ active.label }}</span>
+              <span>{{ active.display }}</span>
+              <span aria-hidden="true">x</span>
+              <span class="sr-only">Remove {{ active.label }} filter</span>
+            </a>
+          {% endfor %}
+        </div>
+      {% endif %}
+    </div>
+
+    <div data-controller="textarea" class="app-muted-panel">
+      <h2 class="text-base font-semibold text-zinc-950">Save this search</h2>
+      <p class="mt-1 text-sm leading-6 text-zinc-600">Turn the current filters into an email alert.</p>
+      <div class="mt-4">
+        {% if request.user.is_authenticated %}
+          {% if not has_custom_alert_filters %}
+            <p class="app-help">Apply at least one filter before saving an alert.</p>
+          {% else %}
+            <form action="{% url 'create-custom-alert' %}" method="post" enctype="multipart/form-data" class="space-y-3">
+            {% csrf_token %}
+              <div>
+                <label for="name" class="app-label">Alert name</label>
+                {% render_field CustomAlertForm.name id="name" name="name" type="text" required="True" class="app-input mt-1" %}
+              </div>
+              {% render_field CustomAlertForm.email id="email" name="email" type="email" value=request.user.email autocomplete="email" readonly="True" required="True" class="hidden" %}
+              {% render_field CustomAlertForm.filter value=custom_alert_filters required="True" class="hidden" %}
+              <button type="submit" class="btn-primary w-full">Save alert</button>
+            </form>
+          {% endif %}
+        {% else %}
+          <p class="app-help">Log in to save filtered searches as alerts.</p>
+          <div class="mt-4 grid gap-2">
+            <a href="{% url 'account_login' %}" class="btn-primary">Log in</a>
+            <a href="{% url 'account_signup' %}" class="btn-secondary">Create account</a>
+          </div>
+        {% endif %}
+      </div>
+    </div>
   </div>
+
+  <section aria-label="Job results" class="mt-4">
+    <ul role="list" class="space-y-3">
+      {% for object in page_obj %}
+        {% include "components/job-posting.html" with object=object show_name=True %}
+      {% empty %}
+      <li class="empty-state">
+        <h2 class="text-lg font-semibold text-zinc-950">No jobs match these filters</h2>
+        <p class="mx-auto mt-2 max-w-md text-sm leading-6 text-zinc-600">Try removing one filter or broadening the search terms. Saved alerts work best with a few high-signal filters.</p>
+        <a href="{% url 'posts' %}" class="btn-secondary mt-5">Clear filters</a>
+      </li>
+    {% endfor %}
+    </ul>
+
+    <nav class="mt-6 flex items-center justify-between" aria-label="Pagination">
+      <div>
+        {% if page_obj.has_previous %}
+        <a href="?{% url_replace request 'page' page_obj.previous_page_number %}" class="btn-secondary">Previous</a>
+        {% endif %}
+      </div>
+
+      <div>
+        {% if page_obj.has_next %}
+        <a href="?{% url_replace request 'page' page_obj.next_page_number %}" class="btn-primary">Next</a>
+        {% endif %}
+      </div>
+    </nav>
+  </section>
 </div>
 {% endblock content %}
 

--- a/utils/templatetags/url_utils.py
+++ b/utils/templatetags/url_utils.py
@@ -11,6 +11,26 @@ def url_replace(request, key, value):
     return query_params.urlencode()
 
 
+@register.simple_tag
+def url_remove(request, key, value=None):
+    query_params = request.GET.copy()
+    query_params.pop("page", None)
+
+    if value is None:
+        query_params.pop(key, None)
+        return query_params.urlencode()
+
+    values = query_params.getlist(key)
+    values = [current_value for current_value in values if current_value != value]
+
+    if values:
+        query_params.setlist(key, values)
+    else:
+        query_params.pop(key, None)
+
+    return query_params.urlencode()
+
+
 @register.filter
 def replace_quotes(value):
     return value.replace('"', "'")


### PR DESCRIPTION
## Summary
- Add keyword, work mode, source, recency, salary-floor, compensation, and contact filters for jobs
- Move filtering into a full-width search workbench above results and expose active filter chips/result counts
- Improve tech/title typeahead behavior and preserve saved-alert filter payloads

## Testing
- npm run build
- python -m py_compile jobs/filters.py jobs/views.py jobs/utils.py utils/templatetags/url_utils.py jobs/tests.py
- docker run ... python manage.py test jobs.tests.PostFilterTests --settings=hn_jobs.settings.local
- docker run ... python manage.py check --settings=hn_jobs.settings.local
- Django template load smoke test for jobs/all_jobs.html
