### PR TITLE
[Jobs] Extract Rich Posting Details

### DIFF
--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1,4 +1,6 @@
 from datetime import datetime
+from typing import Any
+from typing import Dict
 from typing import List
 from typing import Optional
 
@@ -86,6 +88,7 @@ class JobSchema(Schema):
     company_name: str
     company_url: str
     description: str
+    job_details: Dict[str, Any]
     compensation_summary: Optional[str]
     min_salary: Optional[int]
     max_salary: Optional[int]

--- a/api/views.py
+++ b/api/views.py
@@ -125,6 +125,7 @@ def get_jobs(
             "company_name": post.company.name,
             "company_url": post.company.company_homepage_link,
             "description": post.description,
+            "job_details": post.job_details,
             "compensation_summary": post.compensation_summary,
             "min_salary": post.min_salary,
             "max_salary": post.max_salary,
@@ -264,7 +265,6 @@ def create_blog_post(request: HttpRequest, payload: BlogPostCreateSchema):
         raise HttpError(404, "Author user 'rasulkireev' not found.")
 
     try:
-
         # Check for existing slug
         if BlogPost.objects.filter(slug=payload.slug).exists():
             raise HttpError(400, "Blog post with this slug already exists")

--- a/jobs/enrichment.py
+++ b/jobs/enrichment.py
@@ -18,7 +18,7 @@ client = OpenAI()
 
 URL_PATTERN = re.compile(r"""(?:https?://|www\.)[^\s<>"']+""", re.IGNORECASE)
 TRAILING_URL_PUNCTUATION = ".,;:!?)\\]}'\""
-UNKNOWN_DETAIL_VALUES = {"Unknown", "unknown", "empty", "not specified", "N/A", "null", "None", None}
+UNKNOWN_DETAIL_VALUES = {"unknown", "empty", "not specified", "n/a", "null", "none"}
 
 JOB_DETAIL_LIST_KEYS = {
     "responsibilities",
@@ -520,10 +520,14 @@ def normalize_job_detail_value(key, value):
     if isinstance(value, bool):
         return "Yes" if value else "No"
 
-    if value in UNKNOWN_DETAIL_VALUES:
+    if value is None or isinstance(value, dict):
         return ""
 
-    return str(value or "").strip()
+    value = str(value or "").strip()
+    if value.lower() in UNKNOWN_DETAIL_VALUES:
+        return ""
+
+    return value
 
 
 def merge_context_into_job_details(job_details, context, key_map):

--- a/jobs/enrichment.py
+++ b/jobs/enrichment.py
@@ -511,7 +511,7 @@ def normalize_job_details(job_details):
 
 def normalize_job_detail_value(key, value):
     if key in JOB_DETAIL_LIST_KEYS:
-        return split_context_values(value)
+        return normalize_job_detail_list_value(value)
 
     if isinstance(value, list):
         return ", ".join(str(item).strip() for item in value if str(item).strip())
@@ -527,6 +527,10 @@ def normalize_job_detail_value(key, value):
         return ""
 
     return value
+
+
+def normalize_job_detail_list_value(value):
+    return [item for item in split_context_values(value) if item.lower() not in UNKNOWN_DETAIL_VALUES]
 
 
 def merge_context_into_job_details(job_details, context, key_map):

--- a/jobs/enrichment.py
+++ b/jobs/enrichment.py
@@ -18,6 +18,53 @@ client = OpenAI()
 
 URL_PATTERN = re.compile(r"""(?:https?://|www\.)[^\s<>"']+""", re.IGNORECASE)
 TRAILING_URL_PUNCTUATION = ".,;:!?)\\]}'\""
+UNKNOWN_DETAIL_VALUES = {"Unknown", "unknown", "empty", "not specified", "N/A", "null", "None", None}
+
+JOB_DETAIL_LIST_KEYS = {
+    "responsibilities",
+    "requirements",
+    "required_technologies",
+    "nice_to_have_technologies",
+    "timezone_requirements",
+    "benefits",
+    "duplicate_signals",
+}
+
+JOB_DETAIL_SCALAR_KEYS = [
+    "remote_policy",
+    "remote_scope",
+    "travel_requirements",
+    "relocation_support",
+    "visa_sponsorship",
+    "work_authorization",
+    "security_clearance",
+    "employment_type",
+    "salary_period",
+    "salary_location_basis",
+    "compensation_notes",
+    "equity",
+    "bonus",
+    "application_instructions",
+    "application_email_subject",
+    "portfolio_required",
+    "github_required",
+    "cover_letter_required",
+    "application_deadline",
+    "direct_apply",
+    "industry",
+    "product_or_service",
+    "company_hq",
+    "company_size",
+    "company_stage",
+    "company_funding",
+    "open_source",
+    "company_mission",
+    "job_status",
+    "canonical_job_url",
+    "extraction_confidence",
+]
+
+JOB_DETAIL_KEYS = [*sorted(JOB_DETAIL_LIST_KEYS), *JOB_DETAIL_SCALAR_KEYS]
 
 STRUCTURED_CONTEXT_KEYS = [
     "page_summary",
@@ -28,14 +75,42 @@ STRUCTURED_CONTEXT_KEYS = [
     "job_titles",
     "responsibilities",
     "requirements",
+    "required_technologies",
+    "nice_to_have_technologies",
     "technologies",
     "locations",
     "remote_policy",
+    "remote_scope",
+    "timezone_requirements",
+    "travel_requirements",
+    "relocation_support",
+    "visa_sponsorship",
+    "work_authorization",
+    "security_clearance",
     "compensation",
+    "salary_period",
+    "salary_location_basis",
+    "equity",
+    "bonus",
     "benefits",
     "seniority",
     "employment_type",
     "application_instructions",
+    "application_email_subject",
+    "portfolio_required",
+    "github_required",
+    "cover_letter_required",
+    "application_deadline",
+    "direct_apply",
+    "company_hq",
+    "company_size",
+    "company_stage",
+    "company_funding",
+    "open_source",
+    "company_mission",
+    "job_status",
+    "canonical_job_url",
+    "duplicate_signals",
     "notable_links",
     "confidence",
 ]
@@ -44,10 +119,59 @@ LIST_CONTEXT_KEYS = {
     "job_titles",
     "responsibilities",
     "requirements",
+    "required_technologies",
+    "nice_to_have_technologies",
     "technologies",
     "locations",
+    "timezone_requirements",
     "benefits",
+    "duplicate_signals",
     "notable_links",
+}
+
+JOB_CONTEXT_TO_DETAIL_KEYS = {
+    "responsibilities": "responsibilities",
+    "requirements": "requirements",
+    "required_technologies": "required_technologies",
+    "nice_to_have_technologies": "nice_to_have_technologies",
+    "remote_policy": "remote_policy",
+    "remote_scope": "remote_scope",
+    "timezone_requirements": "timezone_requirements",
+    "travel_requirements": "travel_requirements",
+    "relocation_support": "relocation_support",
+    "visa_sponsorship": "visa_sponsorship",
+    "work_authorization": "work_authorization",
+    "security_clearance": "security_clearance",
+    "compensation": "compensation_notes",
+    "salary_period": "salary_period",
+    "salary_location_basis": "salary_location_basis",
+    "equity": "equity",
+    "bonus": "bonus",
+    "benefits": "benefits",
+    "employment_type": "employment_type",
+    "application_instructions": "application_instructions",
+    "application_email_subject": "application_email_subject",
+    "portfolio_required": "portfolio_required",
+    "github_required": "github_required",
+    "cover_letter_required": "cover_letter_required",
+    "application_deadline": "application_deadline",
+    "direct_apply": "direct_apply",
+    "job_status": "job_status",
+    "canonical_job_url": "canonical_job_url",
+    "duplicate_signals": "duplicate_signals",
+    "confidence": "extraction_confidence",
+}
+
+COMPANY_CONTEXT_TO_DETAIL_KEYS = {
+    "product_or_service": "product_or_service",
+    "industry": "industry",
+    "company_hq": "company_hq",
+    "company_size": "company_size",
+    "company_stage": "company_stage",
+    "company_funding": "company_funding",
+    "open_source": "open_source",
+    "company_mission": "company_mission",
+    "confidence": "extraction_confidence",
 }
 
 
@@ -217,14 +341,42 @@ Return only a valid JSON object with these exact keys:
 - job_titles: array of role titles mentioned
 - responsibilities: array of responsibilities mentioned
 - requirements: array of candidate requirements mentioned
+- required_technologies: array of technologies that appear required for the job
+- nice_to_have_technologies: array of optional or preferred technologies
 - technologies: array of technologies, tools, languages, frameworks, or platforms mentioned
 - locations: array of locations or timezones mentioned
 - remote_policy: remote, hybrid, onsite, timezone, or relocation details
+- remote_scope: worldwide, country-limited, region-limited, timezone-limited, hybrid, onsite, or unclear
+- timezone_requirements: array of timezones or required overlap windows
+- travel_requirements: travel expectations, if visible
+- relocation_support: relocation support or requirement, if visible
+- visa_sponsorship: visa sponsorship details, if visible
+- work_authorization: work authorization restrictions, if visible
+- security_clearance: security clearance requirements, if visible
 - compensation: salary, equity, benefits, or compensation details
+- salary_period: yearly, monthly, hourly, contract, or unclear
+- salary_location_basis: whether salary depends on location, if visible
+- equity: equity details, if visible
+- bonus: bonus details, if visible
 - benefits: array of benefits or perks
 - seniority: seniority level if visible
 - employment_type: full-time, part-time, contractor, internship, etc.
 - application_instructions: how to apply, if stated
+- application_email_subject: required email subject line, if stated
+- portfolio_required: whether a portfolio is required, preferred, not required, or unclear
+- github_required: whether GitHub is required, preferred, not required, or unclear
+- cover_letter_required: whether a cover letter is required, preferred, not required, or unclear
+- application_deadline: deadline or closing date, if visible
+- direct_apply: whether the page supports direct apply, points to another ATS, email, or unclear
+- company_hq: company headquarters, if visible
+- company_size: company size or headcount, if visible
+- company_stage: startup stage, public company status, bootstrapped, etc.
+- company_funding: funding details, if visible
+- open_source: open-source signal or notable public repos, if visible
+- company_mission: concise mission or market description
+- job_status: open, closed, expired, unclear, or another visible status
+- canonical_job_url: canonical job posting URL, if visible
+- duplicate_signals: array of URLs or signals that suggest this posting appears elsewhere
 - notable_links: array of useful links visible in the content
 - confidence: high, medium, or low
 
@@ -308,10 +460,21 @@ def normalize_structured_context(page_context):
 def augment_cleaned_job_data_with_context(cleaned_data, job_posting_context, company_homepage_context):
     job_context = job_posting_context.get("structured", {})
     company_context = company_homepage_context.get("structured", {})
+    job_details = normalize_job_details(cleaned_data.get("job_details", {}))
+
+    merge_context_into_job_details(job_details, job_context, JOB_CONTEXT_TO_DETAIL_KEYS)
+    merge_context_into_job_details(job_details, company_context, COMPANY_CONTEXT_TO_DETAIL_KEYS)
 
     cleaned_data["technologies_used"] = merge_csv_values(
         cleaned_data.get("technologies_used", ""),
         get_context_list(job_context, "technologies"),
+    )
+    cleaned_data["technologies_used"] = merge_csv_values(
+        cleaned_data.get("technologies_used", ""),
+        [
+            *job_details["required_technologies"],
+            *job_details["nice_to_have_technologies"],
+        ],
     )
     cleaned_data["job_titles"] = merge_csv_values(
         cleaned_data.get("job_titles", ""),
@@ -324,8 +487,73 @@ def augment_cleaned_job_data_with_context(cleaned_data, job_posting_context, com
     fill_empty_field(cleaned_data, "description", job_context.get("page_summary", ""))
     fill_empty_field(cleaned_data, "company_name", job_context.get("company_name", ""))
     fill_empty_field(cleaned_data, "company_name", company_context.get("company_name", ""))
+    fill_empty_field(cleaned_data, "remote_timezones", job_details["timezone_requirements"])
+    fill_empty_field(cleaned_data, "capacity", job_details.get("employment_type", ""))
+
+    cleaned_data["job_details"] = job_details
 
     return cleaned_data
+
+
+def normalize_job_details(job_details):
+    if not isinstance(job_details, dict):
+        job_details = {}
+
+    normalized_details = {}
+    for key in JOB_DETAIL_KEYS:
+        normalized_details[key] = normalize_job_detail_value(key, job_details.get(key))
+
+    canonical_url = normalized_details.get("canonical_job_url", "")
+    if canonical_url:
+        normalized_details["canonical_job_url"] = normalize_url(canonical_url)
+
+    return normalized_details
+
+
+def normalize_job_detail_value(key, value):
+    if key in JOB_DETAIL_LIST_KEYS:
+        return split_context_values(value)
+
+    if isinstance(value, list):
+        return ", ".join(str(item).strip() for item in value if str(item).strip())
+
+    if isinstance(value, bool):
+        return "Yes" if value else "No"
+
+    if value in UNKNOWN_DETAIL_VALUES:
+        return ""
+
+    return str(value or "").strip()
+
+
+def merge_context_into_job_details(job_details, context, key_map):
+    for context_key, detail_key in key_map.items():
+        merge_job_detail_value(job_details, detail_key, context.get(context_key))
+
+    return job_details
+
+
+def merge_job_detail_value(job_details, key, value):
+    if key in JOB_DETAIL_LIST_KEYS:
+        job_details[key] = merge_detail_list(job_details.get(key, []), split_context_values(value))
+        return
+
+    value = normalize_job_detail_value(key, value)
+    if value and not job_details.get(key):
+        job_details[key] = value
+
+
+def merge_detail_list(existing_values, additional_values):
+    values = []
+    seen = set()
+
+    for value in [*split_context_values(existing_values), *split_context_values(additional_values)]:
+        key = value.lower()
+        if key not in seen:
+            values.append(value)
+            seen.add(key)
+
+    return values
 
 
 def merge_csv_values(existing_values, additional_values):

--- a/jobs/enrichment.py
+++ b/jobs/enrichment.py
@@ -171,7 +171,6 @@ COMPANY_CONTEXT_TO_DETAIL_KEYS = {
     "company_funding": "company_funding",
     "open_source": "open_source",
     "company_mission": "company_mission",
-    "confidence": "extraction_confidence",
 }
 
 
@@ -588,9 +587,24 @@ def get_context_list(context, key):
 
 def split_context_values(value):
     if isinstance(value, list):
-        return [str(item).strip() for item in value if str(item).strip()]
+        values = []
+        for item in value:
+            if item is None or isinstance(item, dict):
+                continue
 
-    if not value:
+            item = str(item).strip()
+            if item and item.lower() not in UNKNOWN_DETAIL_VALUES:
+                values.append(item)
+
+        return values
+
+    if not value or isinstance(value, dict):
         return []
 
-    return [item.strip() for item in str(value).split(",") if item.strip()]
+    value = str(value).strip()
+    if value.lower() in UNKNOWN_DETAIL_VALUES:
+        return []
+
+    return [
+        item.strip() for item in value.split(",") if item.strip() and item.strip().lower() not in UNKNOWN_DETAIL_VALUES
+    ]

--- a/jobs/migrations/0037_post_job_details.py
+++ b/jobs/migrations/0037_post_job_details.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("jobs", "0036_add_we_work_remotely_post_source"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="post",
+            name="job_details",
+            field=models.JSONField(blank=True, default=dict),
+        ),
+    ]

--- a/jobs/models.py
+++ b/jobs/models.py
@@ -32,6 +32,7 @@ class Post(TimeStampedModel):
     original_text = models.TextField(blank=True)
     titles = models.ManyToManyField("Title", related_name="post", blank=True, through="PostTitle")
     description = models.TextField(blank=True)
+    job_details = models.JSONField(default=dict, blank=True)
     company_homepage_context = models.JSONField(default=dict, blank=True)
     company_homepage_reader_content = models.TextField(blank=True, default="")
     job_posting_context = models.JSONField(default=dict, blank=True)

--- a/jobs/tasks.py
+++ b/jobs/tasks.py
@@ -35,7 +35,12 @@ from hn_jobs.utils import get_tjalerts_logger
 from users.models import CustomUser
 
 from jobs.choices import PostSource
-from jobs.enrichment import augment_cleaned_job_data_with_context, build_reader_context, extract_first_url
+from jobs.enrichment import (
+    augment_cleaned_job_data_with_context,
+    build_reader_context,
+    extract_first_url,
+    normalize_job_details,
+)
 from jobs.filters import PostFilter
 from jobs.models import Alert, AlertEmailSend, Company, Email, Post, Technology, Title
 from jobs.utils import (
@@ -84,6 +89,45 @@ def build_job_extraction_request(text):
         - names_of_the_contact_person - (string of comma separated values)
         - years_of_experience - (string of comma separated values, years of experience required to apply)
         - levels_of_experience - (choose from these options: Junior, Mid-level, Senior, Principal, C-Level. figure out from description, can't be empty)
+        - job_details - (object with the exact keys below. Use empty strings or empty arrays when the post does not contain the field. Do not infer facts that are not present.)
+          - responsibilities: array of primary responsibilities
+          - requirements: array of candidate requirements
+          - required_technologies: array of required technologies, tools, languages, frameworks, platforms, or systems
+          - nice_to_have_technologies: array of optional or preferred technologies
+          - remote_policy: string with remote, hybrid, onsite, timezone, relocation, or office details
+          - remote_scope: string, one of worldwide, country-limited, region-limited, timezone-limited, hybrid, onsite, or unclear
+          - timezone_requirements: array of timezones or required overlap windows
+          - travel_requirements: string
+          - relocation_support: string
+          - visa_sponsorship: string
+          - work_authorization: string
+          - security_clearance: string
+          - employment_type: string, such as full-time, part-time, contractor, internship, freelance, or unclear
+          - salary_period: string, such as yearly, monthly, hourly, contract, or unclear
+          - salary_location_basis: string
+          - compensation_notes: string for compensation details that do not fit salary min/max/currency
+          - equity: string
+          - bonus: string
+          - benefits: array of benefits or perks
+          - application_instructions: string
+          - application_email_subject: string
+          - portfolio_required: string, such as required, preferred, not required, or unclear
+          - github_required: string, such as required, preferred, not required, or unclear
+          - cover_letter_required: string, such as required, preferred, not required, or unclear
+          - application_deadline: string
+          - direct_apply: string, such as direct, ats, email, external, or unclear
+          - industry: string
+          - product_or_service: string
+          - company_hq: string
+          - company_size: string
+          - company_stage: string
+          - company_funding: string
+          - open_source: string
+          - company_mission: string
+          - job_status: string, such as open, closed, expired, unclear, or another visible status
+          - canonical_job_url: string URL
+          - duplicate_signals: array of URLs or visible signals that suggest this posting appears elsewhere
+          - extraction_confidence: string, one of high, medium, or low
 
         Don't add any text and only respond with a JSON Object.
 
@@ -187,6 +231,7 @@ def create_post_from_cleaned_data(
     job_posting_context=None,
     job_posting_reader_content="",
 ):
+    job_details = normalize_job_details(cleaned_data.get("job_details", {}))
     technology_names = split_comma_separated_values(cleaned_data["technologies_used"])
     technologies = []
     for name in technology_names:
@@ -218,6 +263,7 @@ def create_post_from_cleaned_data(
         original_text=cleaned_data["original_text"],
         hn_username=hn_username,
         description=cleaned_data["description"],
+        job_details=job_details,
         company_homepage_context=company_homepage_context or {},
         company_homepage_reader_content=company_homepage_reader_content,
         job_posting_context=job_posting_context or {},
@@ -259,6 +305,7 @@ def create_post_from_cleaned_data(
             "has_email": bool(cleaned_data["emails"]),
             "has_application_link": bool(cleaned_data["company_job_application_link"]),
             "has_salary": bool(post.min_salary or post.max_salary),
+            "has_job_details": any(bool(value) for value in job_details.values()),
             "is_remote": post.is_remote,
         },
         groups=company_group(company_obj),
@@ -543,6 +590,8 @@ def build_remote_ok_extraction_text(remote_ok_job):
         f"Tags: {tags}" if tags else "",
         f"Salary min: {remote_ok_job.get('salary_min')}" if remote_ok_job.get("salary_min") else "",
         f"Salary max: {remote_ok_job.get('salary_max')}" if remote_ok_job.get("salary_max") else "",
+        f"Application URL: {remote_ok_job.get('apply_url')}" if remote_ok_job.get("apply_url") else "",
+        f"Canonical URL: {remote_ok_job.get('url')}" if remote_ok_job.get("url") else "",
         f"Description: {description}" if description else "",
     ]
 
@@ -596,6 +645,7 @@ def apply_remote_ok_structured_defaults(remote_ok_job, extracted_data):
     compensation_summary = build_remote_ok_compensation_summary(remote_ok_job)
     salary_min = coerce_salary(remote_ok_job.get("salary_min"))
     salary_max = coerce_salary(remote_ok_job.get("salary_max"))
+    job_details = normalize_job_details(extracted_data.get("job_details", {}))
 
     extracted_data["company_name"] = extracted_data.get("company_name") or company
     extracted_data["job_titles"] = extracted_data.get("job_titles") or position
@@ -609,6 +659,14 @@ def apply_remote_ok_structured_defaults(remote_ok_job, extracted_data):
         extracted_data["compensation_summary"] = compensation_summary
         extracted_data["min_salary"] = salary_min
         extracted_data["max_salary"] = salary_max
+        job_details["compensation_notes"] = job_details["compensation_notes"] or compensation_summary
+        job_details["salary_period"] = job_details["salary_period"] or "yearly"
+
+    job_details["canonical_job_url"] = job_details["canonical_job_url"] or application_link
+    job_details["remote_policy"] = job_details["remote_policy"] or location or "Remote"
+    job_details["remote_scope"] = job_details["remote_scope"] or "unclear"
+    job_details["direct_apply"] = job_details["direct_apply"] or "external"
+    extracted_data["job_details"] = job_details
 
     return extracted_data
 
@@ -801,6 +859,7 @@ def build_we_work_remotely_extraction_text(we_work_remotely_job):
         "Work arrangement: Remote",
         f"Location: {region}" if region else "",
         f"Category: {category}" if category else "",
+        f"Canonical URL: {we_work_remotely_job.get('url')}" if we_work_remotely_job.get("url") else "",
         f"Description: {description}" if description else "",
     ]
 
@@ -832,6 +891,7 @@ def apply_we_work_remotely_structured_defaults(we_work_remotely_job, extracted_d
     description = we_work_remotely_job.get("description_text") or clean_we_work_remotely_description(
         we_work_remotely_job.get("description")
     )
+    job_details = normalize_job_details(extracted_data.get("job_details", {}))
 
     extracted_data["company_name"] = extracted_data.get("company_name") or company
     extracted_data["job_titles"] = extracted_data.get("job_titles") or position
@@ -839,6 +899,13 @@ def apply_we_work_remotely_structured_defaults(we_work_remotely_job, extracted_d
     extracted_data["is_remote"] = True
     extracted_data["description"] = extracted_data.get("description") or description
     extracted_data["company_job_application_link"] = extracted_data.get("company_job_application_link") or source_url
+    job_details["canonical_job_url"] = job_details["canonical_job_url"] or source_url
+    job_details["remote_policy"] = job_details["remote_policy"] or region or "Remote"
+    job_details["remote_scope"] = job_details["remote_scope"] or (
+        "worldwide" if region == "Anywhere in the World" else "unclear"
+    )
+    job_details["direct_apply"] = job_details["direct_apply"] or "external"
+    extracted_data["job_details"] = job_details
 
     return extracted_data
 
@@ -1054,7 +1121,6 @@ def create_update_min_and_max_salary_jobs():
 
     count = 0
     for job in jobs:
-
         if job.compensation_summary == "" or not has_number(job.compensation_summary):
             job.min_salary = 0
             job.max_salary = 0

--- a/jobs/tests.py
+++ b/jobs/tests.py
@@ -17,6 +17,7 @@ from jobs.enrichment import (
     build_reader_context,
     extract_first_url,
     extract_structured_page_context,
+    normalize_job_details,
     read_url_with_jina,
 )
 from jobs.filters import PostFilter
@@ -427,6 +428,9 @@ class RemoteOkParsingTests(SimpleTestCase):
         assert data["company_job_application_link"] == "https://remoteOK.com/remote-jobs/example-123"
         assert data["min_salary"] == 100000
         assert data["max_salary"] == 140000
+        assert data["job_details"]["canonical_job_url"] == "https://remoteOK.com/remote-jobs/example-123"
+        assert data["job_details"]["remote_policy"] == "Remote"
+        assert data["job_details"]["direct_apply"] == "external"
 
     def test_apply_remote_ok_defaults_prefers_api_salary_summary(self):
         job = {
@@ -637,6 +641,11 @@ class WeWorkRemotelyParsingTests(SimpleTestCase):
         assert data["description"] == "Build APIs."
         assert data["is_remote"] is True
         assert data["company_job_application_link"] == "https://weworkremotely.com/remote-jobs/acme-python-engineer"
+        assert data["job_details"]["canonical_job_url"] == (
+            "https://weworkremotely.com/remote-jobs/acme-python-engineer"
+        )
+        assert data["job_details"]["remote_policy"] == "Anywhere in the World"
+        assert data["job_details"]["remote_scope"] == "worldwide"
 
 
 class PostFilterTests(TestCase):
@@ -804,6 +813,9 @@ class RemoteOkImportTests(TestCase):
         assert post.company_job_application_link == "https://remoteOK.com/remote-jobs/example-123"
         assert post.min_salary == 120000
         assert post.max_salary == 160000
+        assert post.job_details["canonical_job_url"] == "https://remoteOK.com/remote-jobs/example-123"
+        assert post.job_details["compensation_notes"] == "120000 - 160000"
+        assert post.job_details["remote_policy"] == "Worldwide"
         assert list(post.titles.values_list("name", flat=True)) == ["Senior Python Engineer"]
         assert set(post.technologies.values_list("name", flat=True)) == {"Python", "Django"}
         assert Post.objects.filter(source=PostSource.REMOTE_OK, source_external_id="123").exists()
@@ -892,6 +904,11 @@ class WeWorkRemotelyImportTests(TestCase):
         assert post.company_job_application_link == "https://weworkremotely.com/remote-jobs/acme-senior-python-engineer"
         assert post.description == "Build production Django APIs."
         assert post.submitted_datetime.isoformat() == "2026-06-02T20:15:53+00:00"
+        assert post.job_details["canonical_job_url"] == (
+            "https://weworkremotely.com/remote-jobs/acme-senior-python-engineer"
+        )
+        assert post.job_details["remote_policy"] == "Anywhere in the World"
+        assert post.job_details["remote_scope"] == "worldwide"
         assert list(post.titles.values_list("name", flat=True)) == ["Senior Python Engineer"]
         assert set(post.technologies.values_list("name", flat=True)) == {"Python", "Django"}
         assert Post.objects.filter(
@@ -924,6 +941,25 @@ class WeWorkRemotelyImportTests(TestCase):
 class ReaderContextTests(SimpleTestCase):
     def test_extract_first_url_normalizes_embedded_urls(self):
         assert extract_first_url('Apply at <a href="www.example.com/jobs">jobs</a>.') == "https://www.example.com/jobs"
+
+    def test_normalize_job_details_coerces_lists_scalars_and_urls(self):
+        details = normalize_job_details(
+            {
+                "responsibilities": "Build APIs, Review code",
+                "required_technologies": ["Python", "Django"],
+                "benefits": None,
+                "portfolio_required": True,
+                "canonical_job_url": "example.com/jobs/backend,",
+                "unknown_key": "ignored",
+            }
+        )
+
+        assert details["responsibilities"] == ["Build APIs", "Review code"]
+        assert details["required_technologies"] == ["Python", "Django"]
+        assert details["benefits"] == []
+        assert details["portfolio_required"] == "Yes"
+        assert details["canonical_job_url"] == "https://example.com/jobs/backend"
+        assert "unknown_key" not in details
 
     @override_settings(
         JINA_READER_API_KEY="jina-key",
@@ -990,6 +1026,10 @@ class ReaderContextTests(SimpleTestCase):
             "compensation_summary": "",
             "levels_of_experience": "",
             "description": "",
+            "job_details": {
+                "required_technologies": ["Python"],
+                "remote_policy": "Remote within Europe",
+            },
         }
         job_posting_context = {
             "structured": {
@@ -1000,9 +1040,22 @@ class ReaderContextTests(SimpleTestCase):
                 "compensation": "$150k-$180k",
                 "seniority": "Senior",
                 "page_summary": "Build internal platform systems.",
+                "responsibilities": ["Own APIs"],
+                "requirements": ["5 years of backend experience"],
+                "required_technologies": ["Django"],
+                "nice_to_have_technologies": ["Kubernetes"],
+                "timezone_requirements": ["CET overlap"],
+                "employment_type": "Full-time",
+                "application_instructions": "Email your resume.",
             }
         }
-        company_homepage_context = {"structured": {"company_name": "Example Homepage"}}
+        company_homepage_context = {
+            "structured": {
+                "company_name": "Example Homepage",
+                "industry": "Developer tools",
+                "product_or_service": "Internal platform",
+            }
+        }
 
         enriched_data = augment_cleaned_job_data_with_context(
             cleaned_data,
@@ -1012,11 +1065,21 @@ class ReaderContextTests(SimpleTestCase):
 
         assert enriched_data["company_name"] == "Example Co"
         assert enriched_data["job_titles"] == "Backend Engineer, Platform Engineer"
-        assert enriched_data["technologies_used"] == "Python, Django"
+        assert enriched_data["technologies_used"] == "Python, Django, Kubernetes"
         assert enriched_data["locations"] == "Remote, Berlin"
         assert enriched_data["compensation_summary"] == "$150k-$180k"
         assert enriched_data["levels_of_experience"] == "Senior"
         assert enriched_data["description"] == "Build internal platform systems."
+        assert enriched_data["remote_timezones"] == "CET overlap"
+        assert enriched_data["capacity"] == "Full-time"
+        assert enriched_data["job_details"]["responsibilities"] == ["Own APIs"]
+        assert enriched_data["job_details"]["requirements"] == ["5 years of backend experience"]
+        assert enriched_data["job_details"]["required_technologies"] == ["Python", "Django"]
+        assert enriched_data["job_details"]["nice_to_have_technologies"] == ["Kubernetes"]
+        assert enriched_data["job_details"]["remote_policy"] == "Remote within Europe"
+        assert enriched_data["job_details"]["industry"] == "Developer tools"
+        assert enriched_data["job_details"]["product_or_service"] == "Internal platform"
+        assert enriched_data["job_details"]["application_instructions"] == "Email your resume."
 
     @override_settings(OPENAI_PAGE_CONTEXT_EXTRACTION_MODEL="test-model")
     @patch("jobs.enrichment.client.chat.completions.create")

--- a/jobs/tests.py
+++ b/jobs/tests.py
@@ -946,6 +946,7 @@ class ReaderContextTests(SimpleTestCase):
         details = normalize_job_details(
             {
                 "responsibilities": "Build APIs, Review code",
+                "requirements": "Unknown",
                 "required_technologies": ["Python", "Django"],
                 "benefits": ["Health insurance", "Unknown", {"text": "bad"}],
                 "portfolio_required": True,
@@ -957,6 +958,7 @@ class ReaderContextTests(SimpleTestCase):
         )
 
         assert details["responsibilities"] == ["Build APIs", "Review code"]
+        assert details["requirements"] == []
         assert details["required_technologies"] == ["Python", "Django"]
         assert details["benefits"] == ["Health insurance"]
         assert details["portfolio_required"] == "Yes"

--- a/jobs/tests.py
+++ b/jobs/tests.py
@@ -950,6 +950,8 @@ class ReaderContextTests(SimpleTestCase):
                 "benefits": None,
                 "portfolio_required": True,
                 "canonical_job_url": "example.com/jobs/backend,",
+                "application_instructions": {"text": "Apply through the site"},
+                "work_authorization": "N/A",
                 "unknown_key": "ignored",
             }
         )
@@ -959,6 +961,8 @@ class ReaderContextTests(SimpleTestCase):
         assert details["benefits"] == []
         assert details["portfolio_required"] == "Yes"
         assert details["canonical_job_url"] == "https://example.com/jobs/backend"
+        assert details["application_instructions"] == ""
+        assert details["work_authorization"] == ""
         assert "unknown_key" not in details
 
     @override_settings(

--- a/jobs/tests.py
+++ b/jobs/tests.py
@@ -947,7 +947,7 @@ class ReaderContextTests(SimpleTestCase):
             {
                 "responsibilities": "Build APIs, Review code",
                 "required_technologies": ["Python", "Django"],
-                "benefits": None,
+                "benefits": ["Health insurance", "Unknown", {"text": "bad"}],
                 "portfolio_required": True,
                 "canonical_job_url": "example.com/jobs/backend,",
                 "application_instructions": {"text": "Apply through the site"},
@@ -958,7 +958,7 @@ class ReaderContextTests(SimpleTestCase):
 
         assert details["responsibilities"] == ["Build APIs", "Review code"]
         assert details["required_technologies"] == ["Python", "Django"]
-        assert details["benefits"] == []
+        assert details["benefits"] == ["Health insurance"]
         assert details["portfolio_required"] == "Yes"
         assert details["canonical_job_url"] == "https://example.com/jobs/backend"
         assert details["application_instructions"] == ""
@@ -1051,6 +1051,7 @@ class ReaderContextTests(SimpleTestCase):
                 "timezone_requirements": ["CET overlap"],
                 "employment_type": "Full-time",
                 "application_instructions": "Email your resume.",
+                "confidence": "medium",
             }
         }
         company_homepage_context = {
@@ -1058,6 +1059,7 @@ class ReaderContextTests(SimpleTestCase):
                 "company_name": "Example Homepage",
                 "industry": "Developer tools",
                 "product_or_service": "Internal platform",
+                "confidence": "high",
             }
         }
 
@@ -1084,6 +1086,7 @@ class ReaderContextTests(SimpleTestCase):
         assert enriched_data["job_details"]["industry"] == "Developer tools"
         assert enriched_data["job_details"]["product_or_service"] == "Internal platform"
         assert enriched_data["job_details"]["application_instructions"] == "Email your resume."
+        assert enriched_data["job_details"]["extraction_confidence"] == "medium"
 
     @override_settings(OPENAI_PAGE_CONTEXT_EXTRACTION_MODEL="test-model")
     @patch("jobs.enrichment.client.chat.completions.create")

--- a/jobs/utils.py
+++ b/jobs/utils.py
@@ -36,6 +36,7 @@ list_of_expected_keys = [
     "is_onsite",
     "capacity",
     "description",
+    "job_details",
     "technologies_used",
     "company_homepage_link",
     "emails",
@@ -294,7 +295,7 @@ def default_alert_name(alert, idx):
     if "technologies" in alert.filter and len(alert.filter) == 1 and alert.filter["technologies"][0]:
         return f"{Technology.objects.get(id=alert.filter['technologies'][0]).name} Alert"
     else:
-        return alert.name if alert.name else f"Alert #{idx+1}"
+        return alert.name if alert.name else f"Alert #{idx + 1}"
 
 
 def build_intent_alert_suggestions(intent, max_alerts=3):

--- a/templates/components/job-posting.html
+++ b/templates/components/job-posting.html
@@ -1,76 +1,91 @@
 <li class="job-card">
-  {% with titles=object.titles.all technologies=object.technologies.all %}
-  {% with title_count=titles|length technology_count=technologies|length %}
-  <a class="block p-4 sm:p-5" href="{% url 'post' object.id %}">
-    <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-      <div class="min-w-0">
-        <p class="text-xs font-medium text-zinc-500">
-          {% if show_name %}
-            {% if object.company.name %}{{ object.company.name }}{% else %}Stealth company{% endif %}
-          {% else %}
-            Open role
-          {% endif %}
-        </p>
-        {% if object.source != "Hacker News" and object.source_url %}
-        <p class="mt-1 text-xs font-medium text-zinc-500">Source: {{ object.source }}</p>
-        {% endif %}
-        <h3 class="mt-1 truncate text-base font-semibold text-zinc-950">
-          {% if title_count >= 1 and titles.0.name %}
-            {{ titles.0.name }}
-          {% elif show_name and object.company.name %}
-            {{ object.company.name }} hiring
-          {% else %}
-            Developer role
-          {% endif %}
-        </h3>
-      </div>
-      <p class="tabular whitespace-nowrap text-xs text-zinc-500">Posted {{ object.submitted_datetime|timesince }} ago</p>
-    </div>
-
-    <p class="mt-3 line-clamp-3 text-sm leading-6 text-zinc-700">
-      {{ object.description|truncatechars:260 }}
-    </p>
-  </a>
-
-  <div class="grid gap-4 border-t border-zinc-200 px-4 py-4 sm:grid-cols-2 sm:px-5">
-    {% if title_count == 1 and titles.0.name == "" %}
-    {% elif title_count >= 1 %}
-    <div>
-      <h4 class="job-section-label">Roles</h4>
-      <div class="mt-1">
-        {% for title in titles %}
-          {% include "components/title-link.html" with title=title %}
-        {% endfor %}
-      </div>
-    </div>
-    {% endif %}
-
-    {% if technology_count == 1 and technologies.0.name == "" %}
-    {% elif technology_count > 0 %}
-    <div>
-      <h4 class="job-section-label">Tech stack</h4>
-      <div class="mt-1">
-        {% for technology in technologies %}
-          {% include "components/technology-link.html" with technology=technology %}
-        {% endfor %}
-      </div>
-    </div>
-    {% endif %}
-
-    {% if object.locations %}
-    <div>
-      <h4 class="job-section-label">Location</h4>
-      <p class="mt-2 text-sm leading-6 text-zinc-700">{{ object.locations }}</p>
-    </div>
-    {% endif %}
-
-    {% if object.compensation_summary %}
-    <div>
-      <h4 class="job-section-label">Compensation</h4>
-      <p class="mt-2 text-sm leading-6 text-zinc-700">{{ object.compensation_summary }}</p>
-    </div>
-    {% endif %}
-  </div>
-  {% endwith %}
-  {% endwith %}
+    {% with titles=object.titles.all technologies=object.technologies.all %}
+        {% with title_count=titles|length technology_count=technologies|length %}
+            <a class="block p-4 sm:p-5" href="{% url 'post' object.id %}">
+                <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div class="min-w-0">
+                        <p class="text-xs font-medium text-zinc-500">
+                            {% if show_name %}
+                                {% if object.company.name %}
+                                    {{ object.company.name }}
+                                {% else %}
+                                    Stealth company
+                                {% endif %}
+                            {% else %}
+                                Open role
+                            {% endif %}
+                        </p>
+                        {% if object.source != "Hacker News" and object.source_url %}
+                            <p class="mt-1 text-xs font-medium text-zinc-500">Source: {{ object.source }}</p>
+                        {% endif %}
+                        <h3 class="mt-1 truncate text-base font-semibold text-zinc-950">
+                            {% if title_count >= 1 and titles.0.name %}
+                                {{ titles.0.name }}
+                            {% elif show_name and object.company.name %}
+                                {{ object.company.name }} hiring
+                            {% else %}
+                                Developer role
+                            {% endif %}
+                        </h3>
+                    </div>
+                    <p class="tabular whitespace-nowrap text-xs text-zinc-500">Posted {{ object.submitted_datetime|timesince }} ago</p>
+                </div>
+                <p class="mt-3 line-clamp-3 text-sm leading-6 text-zinc-700">{{ object.description|truncatechars:260 }}</p>
+            </a>
+            <div class="grid gap-4 border-t border-zinc-200 px-4 py-4 sm:grid-cols-2 sm:px-5">
+                {% if title_count == 1 and titles.0.name == "" %}
+                {% elif title_count >= 1 %}
+                    <div>
+                        <h4 class="job-section-label">Roles</h4>
+                        <div class="mt-1">
+                            {% for title in titles %}
+                                {% include "components/title-link.html" with title=title %}
+                            {% endfor %}
+                        </div>
+                    </div>
+                {% endif %}
+                {% if technology_count == 1 and technologies.0.name == "" %}
+                {% elif technology_count > 0 %}
+                    <div>
+                        <h4 class="job-section-label">Tech stack</h4>
+                        <div class="mt-1">
+                            {% for technology in technologies %}
+                                {% include "components/technology-link.html" with technology=technology %}
+                            {% endfor %}
+                        </div>
+                    </div>
+                {% endif %}
+                {% if object.locations %}
+                    <div>
+                        <h4 class="job-section-label">Location</h4>
+                        <p class="mt-2 text-sm leading-6 text-zinc-700">{{ object.locations }}</p>
+                    </div>
+                {% endif %}
+                {% if object.job_details.employment_type or object.job_details.remote_policy %}
+                    <div>
+                        <h4 class="job-section-label">Work setup</h4>
+                        <p class="mt-2 text-sm leading-6 text-zinc-700">
+                            {% if object.job_details.employment_type %}{{ object.job_details.employment_type }}{% endif %}
+                            {% if object.job_details.employment_type and object.job_details.remote_policy %}
+                                <span class="text-zinc-400">&middot;</span>
+                            {% endif %}
+                            {% if object.job_details.remote_policy %}{{ object.job_details.remote_policy }}{% endif %}
+                        </p>
+                    </div>
+                {% endif %}
+                {% if object.compensation_summary %}
+                    <div>
+                        <h4 class="job-section-label">Compensation</h4>
+                        <p class="mt-2 text-sm leading-6 text-zinc-700">{{ object.compensation_summary }}</p>
+                    </div>
+                {% endif %}
+                {% if object.job_details.benefits %}
+                    <div>
+                        <h4 class="job-section-label">Benefits</h4>
+                        <p class="mt-2 text-sm leading-6 text-zinc-700">{{ object.job_details.benefits|slice:":3"|join:", " }}</p>
+                    </div>
+                {% endif %}
+            </div>
+        {% endwith %}
+    {% endwith %}
 </li>

--- a/templates/jobs/post_detail.html
+++ b/templates/jobs/post_detail.html
@@ -170,15 +170,18 @@
                                 {% endif %}
                             </section>
                         {% endif %}
-                        {% if technology_count == 1 and technologies.0.name == "" %}
-                        {% elif technology_count > 0 %}
+                        {% if technology_count == 1 and technologies.0.name == "" and not details.required_technologies and not details.nice_to_have_technologies %}
+                        {% elif technology_count > 0 or details.required_technologies or details.nice_to_have_technologies %}
                             <section class="app-panel">
                                 <h2 class="text-sm font-semibold text-zinc-950">Tech stack</h2>
-                                <div class="mt-2">
-                                    {% for technology in technologies %}
-                                        {% include "components/technology-link.html" with technology=technology %}
-                                    {% endfor %}
-                                </div>
+                                {% if technology_count == 1 and technologies.0.name == "" %}
+                                {% elif technology_count > 0 %}
+                                    <div class="mt-2">
+                                        {% for technology in technologies %}
+                                            {% include "components/technology-link.html" with technology=technology %}
+                                        {% endfor %}
+                                    </div>
+                                {% endif %}
                                 {% if details.required_technologies or details.nice_to_have_technologies %}
                                     <div class="mt-4 grid gap-4 sm:grid-cols-2">
                                         {% if details.required_technologies %}

--- a/templates/jobs/post_detail.html
+++ b/templates/jobs/post_detail.html
@@ -4,185 +4,552 @@
 {% load widget_tweaks %}
 {% load date_utils %}
 {% load url_utils %}
-
 {% block meta %}
-<title>{{ object.company.name }} is hiring - {{ object.created | date:"F Y" }}</title>
-{% if is_old %}
-<meta name="robots" content="noindex" />
-{% endif %}
-<meta name="description" content="{{ object.description }}" />
-<link rel="canonical" href="{{ SITE_URL }}/jobs/{{ object.id }}" />
-<meta name="twitter:card" content="summary" />
-<meta name="twitter:creator" content="@rasulkireev" />
-<meta name="twitter:title" content="{{ object.company.name }} is hiring - {{ object.created | date:"F Y" }}" />
-<meta name="twitter:description" content="{{ object.description }}" />
-<meta name="twitter:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
-<meta property="og:title" content="{{ object.company.name }} is hiring - {{ object.created | date:"F Y" }}" />
-<meta property="og:url" content="{{ SITE_URL }}/jobs/{{ object.id }}" />
-<meta property="og:description" content="{{ object.description }}" />
-<meta property="og:image" content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
+    <title>{{ object.company.name }} is hiring - {{ object.created | date:"F Y" }}</title>
+    {% if is_old %}<meta name="robots" content="noindex" />{% endif %}
+    <meta name="description" content="{{ object.description }}" />
+    <link rel="canonical" href="{{ SITE_URL }}/jobs/{{ object.id }}" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:creator" content="@rasulkireev" />
+    <meta name="twitter:title"
+          content="{{ object.company.name }} is hiring - {{ object.created | date:"F Y" }}" />
+    <meta name="twitter:description" content="{{ object.description }}" />
+    <meta name="twitter:image"
+          content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
+    <meta property="og:title"
+          content="{{ object.company.name }} is hiring - {{ object.created | date:"F Y" }}" />
+    <meta property="og:url" content="{{ SITE_URL }}/jobs/{{ object.id }}" />
+    <meta property="og:description" content="{{ object.description }}" />
+    <meta property="og:image"
+          content="{{ SITE_URL }}{% static 'vendors/images/logo.png' %}" />
 {% endblock meta %}
-
 {% block content %}
-{% with titles=object.titles.all technologies=object.technologies.all %}
-{% with title_count=titles|length technology_count=technologies|length %}
-<div class="app-page-header">
-  <div class="app-container py-8">
-    <a href="{% url 'posts' %}" class="btn-quiet -ml-3 mb-4">
-      <svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
-      </svg>
-      Back to jobs
-    </a>
-
-    <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-      <div class="min-w-0">
-        <p class="tabular text-sm text-zinc-500">Posted {{ object.submitted_datetime|timesince }} ago</p>
-        <h1 class="mt-2 text-2xl font-semibold tracking-tight text-zinc-950 sm:text-3xl">
-          {% if object.company.name %}{{ object.company.name }}{% else %}Stealth company{% endif %}
-        </h1>
-        {% if title_count >= 1 and titles.0.name %}
-        <p class="mt-2 text-base font-medium text-zinc-700">{{ titles.0.name }}</p>
-        {% endif %}
-      </div>
-
-      <div class="flex flex-wrap gap-2">
-        {% if object.company_job_application_link %}
-        <a href="{{ object.split_application_links.0 }}?utm_source=gettjalerts.com" target="_blank" class="btn-primary">Apply</a>
-        {% endif %}
-        {% if object.source == "Hacker News" %}
-        <a href="https://news.ycombinator.com/item?id={{ object.who_is_hiring_comment_id }}&utm_source=gettjalerts.com" target="_blank" class="btn-secondary gap-2">
-          <img src="{% static 'vendors/images/source-hacker-news.svg' %}" alt="" class="h-4 w-4 shrink-0 rounded-sm" aria-hidden="true" />
-          View on Hacker News
-        </a>
-        {% elif object.source == "Remote OK" and object.source_url %}
-        <a href="{{ object.source_url }}" target="_blank" class="btn-secondary gap-2">
-          <img src="{% static 'vendors/images/source-remote-ok.png' %}" alt="" class="h-4 w-4 shrink-0 rounded-sm" aria-hidden="true" />
-          View on Remote OK
-        </a>
-        {% elif object.source_url %}
-        <a href="{{ object.source_url }}" target="_blank" class="btn-secondary gap-2">
-          View on {{ object.source }}
-        </a>
-        {% endif %}
-        {% if object.company.company_homepage_link %}
-        <a href="{{ object.company.fixed_company_homepage_link }}" target="_blank" class="btn-secondary">Company site</a>
-        {% endif %}
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="app-container py-8">
-  <div class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
-    <article class="space-y-4">
-      {% if title_count == 1 and titles.0.name == "" %}
-      {% elif title_count >= 1 %}
-      <section class="app-panel">
-        <h2 class="text-sm font-semibold text-zinc-950">Roles</h2>
-        <div class="mt-2">
-          {% for title in titles %}
-            {% include "components/title-link.html" with title=title %}
-          {% endfor %}
-        </div>
-      </section>
-      {% endif %}
-
-      {% if object.compensation_summary %}
-      <section class="app-panel">
-        <h2 class="text-sm font-semibold text-zinc-950">Compensation</h2>
-        <p class="mt-2 text-sm leading-6 text-zinc-700">{{ object.compensation_summary }}</p>
-      </section>
-      {% endif %}
-
-      {% if technology_count == 1 and technologies.0.name == "" %}
-      {% elif technology_count > 0 %}
-      <section class="app-panel">
-        <h2 class="text-sm font-semibold text-zinc-950">Tech stack</h2>
-        <div class="mt-2">
-          {% for technology in technologies %}
-            {% include "components/technology-link.html" with technology=technology %}
-          {% endfor %}
-        </div>
-      </section>
-      {% endif %}
-
-      {% if object.locations %}
-      <section class="app-panel">
-        <h2 class="text-sm font-semibold text-zinc-950">Location</h2>
-        <p class="mt-2 text-sm leading-6 text-zinc-700">{{ object.locations }}</p>
-      </section>
-      {% endif %}
-
-      {% if object.names_of_the_contact_person or object.emails %}
-      <section class="app-panel">
-        <h2 class="text-sm font-semibold text-zinc-950">Contact</h2>
-        {% if object.names_of_the_contact_person %}
-        <p class="mt-2 text-sm leading-6 text-zinc-700">{{ object.names_of_the_contact_person }}</p>
-        {% endif %}
-        {% if object.emails %}
-        <p class="mt-1 text-sm leading-6 text-zinc-700">{{ object.emails }}</p>
-        {% endif %}
-      </section>
-      {% endif %}
-
-      <section class="app-panel">
-        <h2 class="text-sm font-semibold text-zinc-950">Description</h2>
-        <div class="prose prose-zinc mt-3 max-w-none">
-          <p>{{ object.description }}</p>
-        </div>
-      </section>
-
-      <section data-controller="similar-posts" data-similar-posts-post-id-value="{{ object.id }}">
-        <div class="mb-3 flex items-center justify-between">
-          <h2 class="text-lg font-semibold text-zinc-950">Similar jobs</h2>
-        </div>
-        <ul data-similar-posts-target="container" role="list" class="space-y-3">
-          <li class="app-panel">
-            <p class="text-sm text-zinc-600">Loading similar jobs...</p>
-          </li>
-        </ul>
-      </section>
-    </article>
-
-    <aside class="space-y-4 lg:sticky lg:top-24 lg:self-start">
-      <div class="app-panel">
-        <h2 class="text-base font-semibold text-zinc-950">Get matching jobs by email</h2>
-        <p class="mt-1 text-sm leading-6 text-zinc-600">Create a simple alert for one technology, or use the jobs page for a more specific saved search.</p>
-        <div class="mt-4">
-          {% include "components/simple-alert-form.html" with create_alert_form=create_alert_form %}
-        </div>
-      </div>
-
-      <div class="app-muted-panel">
-        <h2 class="text-sm font-semibold text-zinc-950">Source</h2>
-        <dl class="mt-3 space-y-3 text-sm">
-          <div class="flex justify-between gap-4">
-            <dt class="text-zinc-500">Posted</dt>
-            <dd class="tabular text-right font-medium text-zinc-900">{{ object.submitted_datetime|date:"M j, Y" }}</dd>
-          </div>
-          <div class="flex justify-between gap-4">
-            <dt class="text-zinc-500">Source</dt>
-            <dd class="text-right font-medium text-zinc-900">
-              {% if object.source != "Hacker News" and object.source_url %}
-              <a href="{{ object.source_url }}" target="_blank" class="hover:text-zinc-700">{{ object.source }}</a>
-              {% else %}
-              {{ object.source }}
-              {% endif %}
-            </dd>
-          </div>
-        </dl>
-      </div>
-    </aside>
-  </div>
-</div>
-{% endwith %}
-{% endwith %}
+    {% with titles=object.titles.all technologies=object.technologies.all details=object.job_details %}
+        {% with title_count=titles|length technology_count=technologies|length %}
+            <div class="app-page-header">
+                <div class="app-container py-8">
+                    <a href="{% url 'posts' %}" class="btn-quiet -ml-3 mb-4">
+                        <svg class="mr-2 h-4 w-4"
+                             fill="none"
+                             viewBox="0 0 24 24"
+                             stroke-width="1.8"
+                             stroke="currentColor"
+                             aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
+                        </svg>
+                        Back to jobs
+                    </a>
+                    <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                        <div class="min-w-0">
+                            <p class="tabular text-sm text-zinc-500">Posted {{ object.submitted_datetime|timesince }} ago</p>
+                            <h1 class="mt-2 text-2xl font-semibold tracking-tight text-zinc-950 sm:text-3xl">
+                                {% if object.company.name %}
+                                    {{ object.company.name }}
+                                {% else %}
+                                    Stealth company
+                                {% endif %}
+                            </h1>
+                            {% if title_count >= 1 and titles.0.name %}
+                                <p class="mt-2 text-base font-medium text-zinc-700">{{ titles.0.name }}</p>
+                            {% endif %}
+                        </div>
+                        <div class="flex flex-wrap gap-2">
+                            {% if object.company_job_application_link %}
+                                <a href="{{ object.split_application_links.0 }}?utm_source=gettjalerts.com"
+                                   target="_blank"
+                                   class="btn-primary">Apply</a>
+                            {% endif %}
+                            {% if object.source == "Hacker News" %}
+                                <a href="https://news.ycombinator.com/item?id={{ object.who_is_hiring_comment_id }}&utm_source=gettjalerts.com"
+                                   target="_blank"
+                                   class="btn-secondary gap-2">
+                                    <img src="{% static 'vendors/images/source-hacker-news.svg' %}"
+                                         alt=""
+                                         class="h-4 w-4 shrink-0 rounded-sm"
+                                         aria-hidden="true" />
+                                    View on Hacker News
+                                </a>
+                            {% elif object.source == "Remote OK" and object.source_url %}
+                                <a href="{{ object.source_url }}"
+                                   target="_blank"
+                                   class="btn-secondary gap-2">
+                                    <img src="{% static 'vendors/images/source-remote-ok.png' %}"
+                                         alt=""
+                                         class="h-4 w-4 shrink-0 rounded-sm"
+                                         aria-hidden="true" />
+                                    View on Remote OK
+                                </a>
+                            {% elif object.source_url %}
+                                <a href="{{ object.source_url }}"
+                                   target="_blank"
+                                   class="btn-secondary gap-2">View on {{ object.source }}</a>
+                            {% endif %}
+                            {% if object.company.company_homepage_link %}
+                                <a href="{{ object.company.fixed_company_homepage_link }}"
+                                   target="_blank"
+                                   class="btn-secondary">Company site</a>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="app-container py-8">
+                <div class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+                    <article class="space-y-4">
+                        {% if title_count == 1 and titles.0.name == "" %}
+                        {% elif title_count >= 1 %}
+                            <section class="app-panel">
+                                <h2 class="text-sm font-semibold text-zinc-950">Roles</h2>
+                                <div class="mt-2">
+                                    {% for title in titles %}
+                                        {% include "components/title-link.html" with title=title %}
+                                    {% endfor %}
+                                </div>
+                            </section>
+                        {% endif %}
+                        {% if object.compensation_summary or details.compensation_notes or details.equity or details.bonus or details.salary_period or details.salary_location_basis or details.benefits %}
+                            <section class="app-panel">
+                                <h2 class="text-sm font-semibold text-zinc-950">Compensation</h2>
+                                {% if object.min_salary or object.max_salary %}
+                                    <p class="mt-2 text-sm font-semibold leading-6 text-zinc-900">
+                                        {% if object.currency %}{{ object.currency }}{% endif %}
+                                        {% if object.min_salary %}{{ object.min_salary }}{% endif %}
+                                        {% if object.min_salary and object.max_salary and object.min_salary != object.max_salary %}
+                                            - {{ object.max_salary }}
+                                        {% elif object.max_salary and not object.min_salary %}
+                                            {{ object.max_salary }}
+                                        {% endif %}
+                                    </p>
+                                {% endif %}
+                                {% if object.compensation_summary %}
+                                    <p class="mt-2 text-sm leading-6 text-zinc-700">{{ object.compensation_summary }}</p>
+                                {% elif details.compensation_notes %}
+                                    <p class="mt-2 text-sm leading-6 text-zinc-700">{{ details.compensation_notes }}</p>
+                                {% endif %}
+                                <dl class="mt-3 grid gap-3 text-sm sm:grid-cols-2">
+                                    {% if details.salary_period %}
+                                        <div>
+                                            <dt class="job-section-label">Salary period</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.salary_period }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if details.salary_location_basis %}
+                                        <div>
+                                            <dt class="job-section-label">Location basis</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.salary_location_basis }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if details.equity %}
+                                        <div>
+                                            <dt class="job-section-label">Equity</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.equity }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if details.bonus %}
+                                        <div>
+                                            <dt class="job-section-label">Bonus</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.bonus }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                </dl>
+                                {% if details.benefits %}
+                                    <div class="mt-4">
+                                        <h3 class="job-section-label">Benefits</h3>
+                                        <ul class="mt-2 grid gap-2 text-sm leading-6 text-zinc-700 sm:grid-cols-2">
+                                            {% for benefit in details.benefits %}<li class="rounded-md bg-zinc-50 px-3 py-2">{{ benefit }}</li>{% endfor %}
+                                        </ul>
+                                    </div>
+                                {% endif %}
+                            </section>
+                        {% endif %}
+                        {% if technology_count == 1 and technologies.0.name == "" %}
+                        {% elif technology_count > 0 %}
+                            <section class="app-panel">
+                                <h2 class="text-sm font-semibold text-zinc-950">Tech stack</h2>
+                                <div class="mt-2">
+                                    {% for technology in technologies %}
+                                        {% include "components/technology-link.html" with technology=technology %}
+                                    {% endfor %}
+                                </div>
+                                {% if details.required_technologies or details.nice_to_have_technologies %}
+                                    <div class="mt-4 grid gap-4 sm:grid-cols-2">
+                                        {% if details.required_technologies %}
+                                            <div>
+                                                <h3 class="job-section-label">Required</h3>
+                                                <div class="mt-2">
+                                                    {% for technology in details.required_technologies %}<span class="tag-neutral">{{ technology }}</span>{% endfor %}
+                                                </div>
+                                            </div>
+                                        {% endif %}
+                                        {% if details.nice_to_have_technologies %}
+                                            <div>
+                                                <h3 class="job-section-label">Nice to have</h3>
+                                                <div class="mt-2">
+                                                    {% for technology in details.nice_to_have_technologies %}<span class="tag-neutral">{{ technology }}</span>{% endfor %}
+                                                </div>
+                                            </div>
+                                        {% endif %}
+                                    </div>
+                                {% endif %}
+                            </section>
+                        {% endif %}
+                        {% if object.locations %}
+                            <section class="app-panel">
+                                <h2 class="text-sm font-semibold text-zinc-950">Location</h2>
+                                <p class="mt-2 text-sm leading-6 text-zinc-700">{{ object.locations }}</p>
+                            </section>
+                        {% endif %}
+                        {% if details.employment_type or object.capacity or details.remote_policy or details.remote_scope or details.timezone_requirements or details.travel_requirements or details.relocation_support or details.visa_sponsorship or details.work_authorization or details.security_clearance or object.levels_of_experience or object.years_of_experience %}
+                            <section class="app-panel">
+                                <h2 class="text-sm font-semibold text-zinc-950">Work setup</h2>
+                                <dl class="mt-3 grid gap-3 text-sm sm:grid-cols-2">
+                                    {% if details.employment_type or object.capacity %}
+                                        <div>
+                                            <dt class="job-section-label">Employment</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.employment_type|default:object.capacity }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if object.levels_of_experience %}
+                                        <div>
+                                            <dt class="job-section-label">Level</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ object.levels_of_experience }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if object.years_of_experience %}
+                                        <div>
+                                            <dt class="job-section-label">Experience</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ object.years_of_experience }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if details.remote_policy %}
+                                        <div>
+                                            <dt class="job-section-label">Remote policy</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.remote_policy }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if details.remote_scope %}
+                                        <div>
+                                            <dt class="job-section-label">Remote scope</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.remote_scope }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if details.timezone_requirements %}
+                                        <div>
+                                            <dt class="job-section-label">Timezones</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.timezone_requirements|join:", " }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if details.travel_requirements %}
+                                        <div>
+                                            <dt class="job-section-label">Travel</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.travel_requirements }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if details.relocation_support %}
+                                        <div>
+                                            <dt class="job-section-label">Relocation</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.relocation_support }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if details.visa_sponsorship %}
+                                        <div>
+                                            <dt class="job-section-label">Visa</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.visa_sponsorship }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if details.work_authorization %}
+                                        <div>
+                                            <dt class="job-section-label">Authorization</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.work_authorization }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if details.security_clearance %}
+                                        <div>
+                                            <dt class="job-section-label">Clearance</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.security_clearance }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                </dl>
+                            </section>
+                        {% endif %}
+                        {% if details.responsibilities or details.requirements %}
+                            <section class="app-panel">
+                                <h2 class="text-sm font-semibold text-zinc-950">Role details</h2>
+                                <div class="mt-3 grid gap-6 md:grid-cols-2">
+                                    {% if details.responsibilities %}
+                                        <div>
+                                            <h3 class="job-section-label">Responsibilities</h3>
+                                            <ul class="mt-2 space-y-2 text-sm leading-6 text-zinc-700">
+                                                {% for responsibility in details.responsibilities %}<li>{{ responsibility }}</li>{% endfor %}
+                                            </ul>
+                                        </div>
+                                    {% endif %}
+                                    {% if details.requirements %}
+                                        <div>
+                                            <h3 class="job-section-label">Requirements</h3>
+                                            <ul class="mt-2 space-y-2 text-sm leading-6 text-zinc-700">
+                                                {% for requirement in details.requirements %}<li>{{ requirement }}</li>{% endfor %}
+                                            </ul>
+                                        </div>
+                                    {% endif %}
+                                </div>
+                            </section>
+                        {% endif %}
+                        {% if details.application_instructions or details.application_email_subject or details.portfolio_required or details.github_required or details.cover_letter_required or details.application_deadline or details.direct_apply or details.canonical_job_url %}
+                            <section class="app-panel">
+                                <h2 class="text-sm font-semibold text-zinc-950">Application</h2>
+                                {% if details.application_instructions %}
+                                    <p class="mt-2 text-sm leading-6 text-zinc-700">{{ details.application_instructions }}</p>
+                                {% endif %}
+                                <dl class="mt-3 grid gap-3 text-sm sm:grid-cols-2">
+                                    {% if details.application_email_subject %}
+                                        <div>
+                                            <dt class="job-section-label">Email subject</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.application_email_subject }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if details.application_deadline %}
+                                        <div>
+                                            <dt class="job-section-label">Deadline</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.application_deadline }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if details.portfolio_required %}
+                                        <div>
+                                            <dt class="job-section-label">Portfolio</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.portfolio_required }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if details.github_required %}
+                                        <div>
+                                            <dt class="job-section-label">GitHub</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.github_required }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if details.cover_letter_required %}
+                                        <div>
+                                            <dt class="job-section-label">Cover letter</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.cover_letter_required }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if details.direct_apply %}
+                                        <div>
+                                            <dt class="job-section-label">Apply flow</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.direct_apply }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if details.canonical_job_url %}
+                                        <div>
+                                            <dt class="job-section-label">Canonical URL</dt>
+                                            <dd class="mt-1 break-words leading-6 text-zinc-700">
+                                                <a href="{{ details.canonical_job_url }}"
+                                                   target="_blank"
+                                                   class="hover:text-zinc-950">{{ details.canonical_job_url }}</a>
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                </dl>
+                            </section>
+                        {% endif %}
+                        {% if details.industry or details.product_or_service or details.company_hq or details.company_size or details.company_stage or details.company_funding or details.open_source or details.company_mission %}
+                            <section class="app-panel">
+                                <h2 class="text-sm font-semibold text-zinc-950">Company context</h2>
+                                {% if details.company_mission %}
+                                    <p class="mt-2 text-sm leading-6 text-zinc-700">{{ details.company_mission }}</p>
+                                {% endif %}
+                                <dl class="mt-3 grid gap-3 text-sm sm:grid-cols-2">
+                                    {% if details.product_or_service %}
+                                        <div>
+                                            <dt class="job-section-label">Product</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.product_or_service }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if details.industry %}
+                                        <div>
+                                            <dt class="job-section-label">Industry</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.industry }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if details.company_hq %}
+                                        <div>
+                                            <dt class="job-section-label">HQ</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.company_hq }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if details.company_size %}
+                                        <div>
+                                            <dt class="job-section-label">Size</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.company_size }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if details.company_stage %}
+                                        <div>
+                                            <dt class="job-section-label">Stage</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.company_stage }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if details.company_funding %}
+                                        <div>
+                                            <dt class="job-section-label">Funding</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.company_funding }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                    {% if details.open_source %}
+                                        <div>
+                                            <dt class="job-section-label">Open source</dt>
+                                            <dd class="mt-1 leading-6 text-zinc-700">
+                                                {{ details.open_source }}
+                                            </dd>
+                                        </div>
+                                    {% endif %}
+                                </dl>
+                            </section>
+                        {% endif %}
+                        {% if object.names_of_the_contact_person or object.emails %}
+                            <section class="app-panel">
+                                <h2 class="text-sm font-semibold text-zinc-950">Contact</h2>
+                                {% if object.names_of_the_contact_person %}
+                                    <p class="mt-2 text-sm leading-6 text-zinc-700">{{ object.names_of_the_contact_person }}</p>
+                                {% endif %}
+                                {% if object.emails %}<p class="mt-1 text-sm leading-6 text-zinc-700">{{ object.emails }}</p>{% endif %}
+                            </section>
+                        {% endif %}
+                        <section class="app-panel">
+                            <h2 class="text-sm font-semibold text-zinc-950">Description</h2>
+                            <div class="prose prose-zinc mt-3 max-w-none">
+                                <p>{{ object.description }}</p>
+                            </div>
+                        </section>
+                        <section data-controller="similar-posts"
+                                 data-similar-posts-post-id-value="{{ object.id }}">
+                            <div class="mb-3 flex items-center justify-between">
+                                <h2 class="text-lg font-semibold text-zinc-950">Similar jobs</h2>
+                            </div>
+                            <ul data-similar-posts-target="container" role="list" class="space-y-3">
+                                <li class="app-panel">
+                                    <p class="text-sm text-zinc-600">Loading similar jobs...</p>
+                                </li>
+                            </ul>
+                        </section>
+                    </article>
+                    <aside class="space-y-4 lg:sticky lg:top-24 lg:self-start">
+                        <div class="app-panel">
+                            <h2 class="text-base font-semibold text-zinc-950">Get matching jobs by email</h2>
+                            <p class="mt-1 text-sm leading-6 text-zinc-600">
+                                Create a simple alert for one technology, or use the jobs page for a more specific saved search.
+                            </p>
+                            <div class="mt-4">{% include "components/simple-alert-form.html" with create_alert_form=create_alert_form %}</div>
+                        </div>
+                        <div class="app-muted-panel">
+                            <h2 class="text-sm font-semibold text-zinc-950">Source</h2>
+                            <dl class="mt-3 space-y-3 text-sm">
+                                <div class="flex justify-between gap-4">
+                                    <dt class="text-zinc-500">Posted</dt>
+                                    <dd class="tabular text-right font-medium text-zinc-900">
+                                        {{ object.submitted_datetime|date:"M j, Y" }}
+                                    </dd>
+                                </div>
+                                <div class="flex justify-between gap-4">
+                                    <dt class="text-zinc-500">Source</dt>
+                                    <dd class="text-right font-medium text-zinc-900">
+                                        {% if object.source != "Hacker News" and object.source_url %}
+                                            <a href="{{ object.source_url }}"
+                                               target="_blank"
+                                               class="hover:text-zinc-700">{{ object.source }}</a>
+                                        {% else %}
+                                            {{ object.source }}
+                                        {% endif %}
+                                    </dd>
+                                </div>
+                                {% if details.job_status %}
+                                    <div class="flex justify-between gap-4">
+                                        <dt class="text-zinc-500">Status</dt>
+                                        <dd class="text-right font-medium text-zinc-900">
+                                            {{ details.job_status }}
+                                        </dd>
+                                    </div>
+                                {% endif %}
+                                {% if details.extraction_confidence %}
+                                    <div class="flex justify-between gap-4">
+                                        <dt class="text-zinc-500">Detail confidence</dt>
+                                        <dd class="text-right font-medium text-zinc-900">
+                                            {{ details.extraction_confidence }}
+                                        </dd>
+                                    </div>
+                                {% endif %}
+                            </dl>
+                            {% if details.duplicate_signals %}
+                                <div class="mt-4 border-t border-zinc-200 pt-4">
+                                    <h3 class="job-section-label">Also appears</h3>
+                                    <ul class="mt-2 space-y-2 text-sm leading-6 text-zinc-700">
+                                        {% for signal in details.duplicate_signals %}<li class="break-words">{{ signal }}</li>{% endfor %}
+                                    </ul>
+                                </div>
+                            {% endif %}
+                        </div>
+                    </aside>
+                </div>
+            </div>
+        {% endwith %}
+    {% endwith %}
 {% endblock content %}
-
 {% block schema %}
-  {% with titles=object.titles.all %}
-  <script type="application/ld+json">
+    {% with titles=object.titles.all %}
+        <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "JobPosting",
@@ -204,6 +571,6 @@
         "sameAs": "{{ object.company.fixed_company_homepage_link }}"{% endif %}
       }
     }
-  </script>
-  {% endwith %}
+        </script>
+    {% endwith %}
 {% endblock schema %}


### PR DESCRIPTION
## Summary
- add a structured job_details JSON field for richer AI-extracted posting data
- expand HN, RemoteOK, WWR, and reader-context extraction to capture responsibilities, requirements, required/nice-to-have tech, remote policy, authorization, compensation, application, company, and freshness details
- surface rich details on job cards, job detail pages, and the jobs API

## Test plan
- [x] PYENV_VERSION=3.11.6 python -m ruff check jobs/enrichment.py jobs/tasks.py jobs/utils.py jobs/tests.py api/schemas.py api/views.py
- [x] PYENV_VERSION=3.11.6 djlint templates/components/job-posting.html templates/jobs/post_detail.html --check
- [x] python -m py_compile jobs/enrichment.py jobs/tasks.py jobs/utils.py jobs/models.py jobs/tests.py api/schemas.py api/views.py
- [x] git diff --check tjalerts/main...HEAD
- [x] ENVIRONMENT=local ... /Users/rasul/code/tjalerts/.venv/bin/python manage.py test

## Notes
- Full tests ran against an isolated temporary Postgres container on port 55432 because SQLite cannot apply the existing pgvector/HNSW migrations.