### PR TITLE
[API] Filter Jobs By Source

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -1,1 +1,42 @@
-# Create your tests here.
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from jobs.choices import PostSource
+from jobs.models import Company, Post
+
+
+class JobsApiTests(TestCase):
+    def setUp(self):
+        company = Company.objects.create(name="Acme")
+        Post.objects.create(
+            company=company,
+            submitted_datetime=timezone.now(),
+            description="HN role",
+            source=PostSource.HACKER_NEWS,
+        )
+        Post.objects.create(
+            company=company,
+            submitted_datetime=timezone.now(),
+            description="Remote OK role",
+            source=PostSource.REMOTE_OK,
+        )
+        Post.objects.create(
+            company=company,
+            submitted_datetime=timezone.now(),
+            description="WWR role",
+            source=PostSource.WE_WORK_REMOTELY,
+        )
+
+    def test_jobs_endpoint_filters_by_source(self):
+        response = self.client.get(reverse("api-1.0.0:get_jobs"), {"source": PostSource.REMOTE_OK})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["count"] == 1
+        assert [job["source"] for job in data["jobs"]] == [PostSource.REMOTE_OK]
+
+    def test_jobs_endpoint_rejects_invalid_source(self):
+        response = self.client.get(reverse("api-1.0.0:get_jobs"), {"source": "LinkedIn"})
+
+        assert response.status_code == 400

--- a/api/tests.py
+++ b/api/tests.py
@@ -9,32 +9,49 @@ from jobs.models import Company, Post
 class JobsApiTests(TestCase):
     def setUp(self):
         company = Company.objects.create(name="Acme")
-        Post.objects.create(
+        self.hacker_news_post = Post.objects.create(
             company=company,
             submitted_datetime=timezone.now(),
             description="HN role",
             source=PostSource.HACKER_NEWS,
         )
-        Post.objects.create(
+        self.remote_ok_post = Post.objects.create(
             company=company,
             submitted_datetime=timezone.now(),
             description="Remote OK role",
             source=PostSource.REMOTE_OK,
         )
-        Post.objects.create(
+        self.we_work_remotely_post = Post.objects.create(
             company=company,
             submitted_datetime=timezone.now(),
             description="WWR role",
             source=PostSource.WE_WORK_REMOTELY,
         )
 
-    def test_jobs_endpoint_filters_by_source(self):
-        response = self.client.get(reverse("api-1.0.0:get_jobs"), {"source": PostSource.REMOTE_OK})
+    def test_jobs_endpoint_returns_all_sources_without_source_filter(self):
+        response = self.client.get(reverse("api-1.0.0:get_jobs"))
 
         assert response.status_code == 200
         data = response.json()
-        assert data["count"] == 1
-        assert [job["source"] for job in data["jobs"]] == [PostSource.REMOTE_OK]
+        assert data["count"] == 3
+        assert {job["source"] for job in data["jobs"]} == set(PostSource.values)
+
+    def test_jobs_endpoint_filters_by_source(self):
+        expected_post_ids = {
+            PostSource.HACKER_NEWS: str(self.hacker_news_post.id),
+            PostSource.REMOTE_OK: str(self.remote_ok_post.id),
+            PostSource.WE_WORK_REMOTELY: str(self.we_work_remotely_post.id),
+        }
+
+        for source, expected_post_id in expected_post_ids.items():
+            with self.subTest(source=source):
+                response = self.client.get(reverse("api-1.0.0:get_jobs"), {"source": source})
+
+                assert response.status_code == 200
+                data = response.json()
+                assert data["count"] == 1
+                assert [job["id"] for job in data["jobs"]] == [expected_post_id]
+                assert [job["source"] for job in data["jobs"]] == [source]
 
     def test_jobs_endpoint_rejects_invalid_source(self):
         response = self.client.get(reverse("api-1.0.0:get_jobs"), {"source": "LinkedIn"})

--- a/api/views.py
+++ b/api/views.py
@@ -11,6 +11,7 @@ from ninja.errors import HttpError
 from blog.models import BlogPost
 from hn_jobs.posthog_events import capture_request_event
 from hn_jobs.utils import get_tjalerts_logger
+from jobs.choices import PostSource
 from jobs.models import Company, Email, Post, Technology, TechnologyMapping, Title
 from jobs.queries import get_similar_posts_from_db
 from jobs.tasks import create_valid_emails
@@ -80,6 +81,7 @@ def get_emails(
 def get_jobs(
     request,
     technologies=Query(None),
+    source: Optional[str] = Query(None),
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
 ):
@@ -96,6 +98,12 @@ def get_jobs(
             # Filter posts that have ALL the requested technologies
             for tech in tech_objects:
                 posts = posts.filter(technologies=tech)
+
+    if source:
+        if source not in PostSource.values:
+            raise HttpError(400, "Invalid job source")
+
+        posts = posts.filter(source=source)
 
     # Sort by most recent submissions first
     posts = posts.order_by("-submitted_datetime")

--- a/api/views.py
+++ b/api/views.py
@@ -32,6 +32,8 @@ logger = get_tjalerts_logger(__name__)
 
 api = NinjaAPI()
 
+SOURCE_QUERY_DESCRIPTION = "Filter jobs by source. Valid values: Hacker News, Remote OK, We Work Remotely."
+
 
 @api.get("/companies", response=List[ReadCompany])
 def companies(request):
@@ -81,7 +83,7 @@ def get_emails(
 def get_jobs(
     request,
     technologies=Query(None),
-    source: Optional[str] = Query(None),
+    source: Optional[str] = Query(None, description=SOURCE_QUERY_DESCRIPTION),
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
 ):


### PR DESCRIPTION
## Summary
- Add a validated `source` query parameter to the jobs API.
- Return 400 for unknown job source values.
- Cover valid and invalid source filtering in API tests.

## Testing
- `poetry run python manage.py test api.tests jobs.tests.PostFilterTests` with local test env against Postgres.